### PR TITLE
Add size and align attributes to xml output

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -230,6 +230,9 @@ class ASTVisitor: public ASTVisitorBase
   void PrintNameAttribute(std::string const& name);
   void PrintNameAttribute(clang::NamedDecl const* d);
 
+  /** Print an offset="..." attribute. */
+  void PrintOffsetAttribute(unsigned int const& offset);
+
   /** Print a basetype="..." attribute with the XML IDREF for
       the given type.  Also queues the given type for later output.  */
   void PrintBaseTypeAttribute(clang::Type const* c, bool complete);
@@ -907,6 +910,12 @@ void ASTVisitor::PrintNameAttribute(clang::NamedDecl const* d)
 }
 
 //----------------------------------------------------------------------------
+void ASTVisitor::PrintOffsetAttribute(unsigned int const& offset)
+{
+  this->OS << " offset=\"" << offset << "\"";
+}
+
+//----------------------------------------------------------------------------
 void ASTVisitor::PrintBaseTypeAttribute(clang::Type const* c, bool complete)
 {
   this->OS << " basetype=\"";
@@ -1381,6 +1390,7 @@ void ASTVisitor::OutputFieldDecl(clang::FieldDecl const* d, DumpNode const* dn)
   }
   this->PrintContextAttribute(d);
   this->PrintLocationAttribute(d);
+  this->PrintOffsetAttribute(this->CTX.getFieldOffset(d));
   if(d->isMutable()) {
     this->OS << " mutable=\"1\"";
   }

--- a/test/expect/gccxml.any.ArrayType-incomplete.xml.txt
+++ b/test/expect/gccxml.any.ArrayType-incomplete.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
   <ArrayType id="_2" min="0" max="" type="_4"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/ArrayType-incomplete.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.ArrayType.xml.txt
+++ b/test/expect/gccxml.any.ArrayType.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
   <ArrayType id="_2" min="0" max="1" type="_4"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/ArrayType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Class-abstract.xml.txt
+++ b/test/expect/gccxml.any.Class-abstract.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" abstract="1" members="_3 _4 _5 _6 _7 _8"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" abstract="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_9" context="_1" access="private" location="f1:2" file="f1" line="2" virtual="1" pure_virtual="1">
     <Argument type="_9" location="f1:2" file="f1" line="2"/>
   </Method>
@@ -13,7 +13,7 @@
   <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1"/>
   <ReferenceType id="_11" type="_1c"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-base-typedef.xml.txt
+++ b/test/expect/gccxml.any.Class-base-typedef.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:3" file="f1" line="3" members="_3 _4 _5 _6" bases="_7">
+  <Class id="_1" name="start" context="_2" location="f1:3" file="f1" line="3" members="_3 _4 _5 _6" bases="_7" size="[0-9]+" align="[0-9]+">
     <Base type="_7" access="public" virtual="0"/>
   </Class>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throws="")?/>
@@ -11,7 +11,7 @@
     <Argument type="_8" location="f1:3" file="f1" line="3"/>
   </OperatorMethod>
   <Destructor id="_6" name="start" context="_1" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throws="")?/>
-  <Class id="_7" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _11 _12 _13"/>
+  <Class id="_7" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _11 _12 _13" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_8" type="_1c"/>
   <ReferenceType id="_9" type="_1"/>
   <Constructor id="_10" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>

--- a/test/expect/gccxml.any.Class-forward.xml.txt
+++ b/test/expect/gccxml.any.Class-forward.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6"/>
+  <Class id="_1" name="start" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:4" file="f1" line="4"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:5" file="f1" line="5">
     <Argument type="_7" location="f1:5" file="f1" line="5"/>

--- a/test/expect/gccxml.any.Class-friends.xml.txt
+++ b/test/expect/gccxml.any.Class-friends.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:3" file="f1" line="3" members="_3 _4 _5 _6" befriending="_7 _8"/>
+  <Class id="_1" name="start" context="_2" location="f1:3" file="f1" line="3" members="_3 _4 _5 _6" befriending="_7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throws="")?>
     <Argument type="_9" location="f1:3" file="f1" line="3"/>
@@ -13,8 +13,8 @@
   <ReferenceType id="_10" type="_1"/>
   <Namespace id="_2" name="::"/>
   <Function id="_7" name="f" returns="_12" context="_2" location="f1:2" file="f1" line="2"/>
-  <Class id="_8" name="A" context="_2" location="f1:1" file="f1" line="1"/>
+  <Class id="_8" name="A" context="_2" location="f1:1" file="f1" line="1" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <FundamentalType id="_12" name="void"/>
+  <FundamentalType id="_12" name="void" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Class-friends.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Class-implicit-member-access-mutable.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-access-mutable.xml.txt
@@ -14,7 +14,7 @@
   <OperatorMethod id="_9" name="=" returns="_12" context="_5" access="private" location="f1:7" file="f1" line="7">
     <Argument type="_11" location="f1:7" file="f1" line="7"/>
   </OperatorMethod>
-  <Field id="_10" name="data" type="_13" context="_5" access="private" location="f1:8" file="f1" line="8" mutable="1"/>
+  <Field id="_10" name="data" type="_13" context="_5" access="private" location="f1:8" file="f1" line="8" offset="0" mutable="1"/>
   <ReferenceType id="_11" type="_5c"/>
   <ReferenceType id="_12" type="_5"/>
   <FundamentalType id="_13" name="int"/>

--- a/test/expect/gccxml.any.Class-implicit-member-access-mutable.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-access-mutable.xml.txt
@@ -1,11 +1,11 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4" bases="_5">
+  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4" bases="_5" size="[0-9]+" align="[0-9]+">
     <Base type="_5" access="public" virtual="0"/>
   </Class>
   <Destructor id="_3" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throws="")?/>
-  <Class id="_5" name="base" context="_2" location="f1:1" file="f1" line="1" members="_6 _7 _8 _9 _10"/>
+  <Class id="_5" name="base" context="_2" location="f1:1" file="f1" line="1" members="_6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_6" name="base" context="_5" access="protected" location="f1:3" file="f1" line="3"/>
   <Destructor id="_7" name="base" context="_5" access="protected" location="f1:4" file="f1" line="4"/>
   <Constructor id="_8" name="base" context="_5" access="private" location="f1:6" file="f1" line="6">
@@ -17,7 +17,7 @@
   <Field id="_10" name="data" type="_13" context="_5" access="private" location="f1:8" file="f1" line="8" offset="0" mutable="1"/>
   <ReferenceType id="_11" type="_5c"/>
   <ReferenceType id="_12" type="_5"/>
-  <FundamentalType id="_13" name="int"/>
+  <FundamentalType id="_13" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <CvQualifiedType id="_5c" type="_5" const="1"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-access-mutable.cxx"/>

--- a/test/expect/gccxml.any.Class-implicit-member-access.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-access.xml.txt
@@ -1,11 +1,11 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4" bases="_5">
+  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4" bases="_5" size="[0-9]+" align="[0-9]+">
     <Base type="_5" access="public" virtual="0"/>
   </Class>
   <Destructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throws="")?/>
-  <Class id="_5" name="base" context="_2" location="f1:1" file="f1" line="1" members="_6 _7 _8 _9"/>
+  <Class id="_5" name="base" context="_2" location="f1:1" file="f1" line="1" members="_6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_6" name="base" context="_5" access="protected" location="f1:3" file="f1" line="3"/>
   <Destructor id="_7" name="base" context="_5" access="protected" location="f1:4" file="f1" line="4"/>
   <Constructor id="_8" name="base" context="_5" access="private" location="f1:6" file="f1" line="6">

--- a/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
@@ -13,7 +13,7 @@
   <ArrayType id="_8" min="0" max="1" type="_11"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
-  <FundamentalType id="_11" name="int"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-array.cxx"/>

--- a/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
-  <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:2" file="f1" line="2"/>
+  <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_9" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.Class-implicit-member-bad-base.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-bad-base.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5" bases="_6">
+  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5" bases="_6" size="[0-9]+" align="[0-9]+">
     <Base type="_6" access="public" virtual="0"/>
   </Class>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throws="")?/>
@@ -8,7 +8,7 @@
     <Argument type="_7" location="f1:9" file="f1" line="9"/>
   </Constructor>
   <Destructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throws="")?/>
-  <Class id="_6" name="base&lt;const int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_8 _9 _10 _11"/>
+  <Class id="_6" name="base&lt;const int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_8 _9 _10 _11" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_7" type="_1c"/>
   <Field id="_8" name="data" type="_14c" context="_6" access="protected" location="f1:3" file="f1" line="3" offset="0"/>
   <Constructor id="_9" name="base" context="_6" access="protected" location="f1:4" file="f1" line="4"/>
@@ -17,7 +17,7 @@
   </Constructor>
   <Destructor id="_11" name="base" context="_6" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <CvQualifiedType id="_14c" type="_14" const="1"/>
-  <FundamentalType id="_14" name="int"/>
+  <FundamentalType id="_14" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_15" type="_6c"/>
   <Namespace id="_2" name="::"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>

--- a/test/expect/gccxml.any.Class-implicit-member-bad-base.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-bad-base.xml.txt
@@ -10,7 +10,7 @@
   <Destructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throws="")?/>
   <Class id="_6" name="base&lt;const int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_8 _9 _10 _11"/>
   <ReferenceType id="_7" type="_1c"/>
-  <Field id="_8" name="data" type="_14c" context="_6" access="protected" location="f1:3" file="f1" line="3"/>
+  <Field id="_8" name="data" type="_14c" context="_6" access="protected" location="f1:3" file="f1" line="3" offset="0"/>
   <Constructor id="_9" name="base" context="_6" access="protected" location="f1:4" file="f1" line="4"/>
   <Constructor id="_10" name="base" context="_6" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_15" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.Class-implicit-member-const.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-const.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="data" type="_8c" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:4" file="f1" line="4"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
@@ -8,7 +8,7 @@
   </Constructor>
   <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <FundamentalType id="_8" name="int"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <Namespace id="_2" name="::"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>

--- a/test/expect/gccxml.any.Class-implicit-member-const.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-const.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
-  <Field id="_3" name="data" type="_8c" context="_1" access="private" location="f1:2" file="f1" line="2"/>
+  <Field id="_3" name="data" type="_8c" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:4" file="f1" line="4"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_9" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.Class-implicit-member-reference.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-reference.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
-  <Field id="_3" name="ref" type="_7" context="_1" access="private" location="f1:2" file="f1" line="2"/>
+  <Field id="_3" name="ref" type="_7" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:4" file="f1" line="4"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_8" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.Class-implicit-member-reference.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-reference.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="ref" type="_7" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:4" file="f1" line="4"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
@@ -10,7 +10,7 @@
   <ReferenceType id="_7" type="_9"/>
   <ReferenceType id="_8" type="_1c"/>
   <Namespace id="_2" name="::"/>
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-reference.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Class-implicit-members.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-members.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_1" context="_1" access="private" location="f1:2" file="f1" line="2" inline="1">
     <Argument name="x" type="_8" location="f1:2" file="f1" line="2"/>
   </Method>

--- a/test/expect/gccxml.any.Class-member-template.xml.txt
+++ b/test/expect/gccxml.any.Class-member-template.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:2" file="f1" line="2" inline="1">
     <Argument name="v" type="_8" location="f1:2" file="f1" line="2"/>
   </Method>
@@ -12,7 +12,7 @@
     <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_8" name="int"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-partial-template-member-Typedef.xml.txt
+++ b/test/expect/gccxml.any.Class-partial-template-member-Typedef.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int &amp;&gt;" context="_2" location="f1:7" file="f1" line="7" members="_3 _4 _5 _6 _7 _8"/>
+  <Class id="_1" name="start&lt;int &amp;&gt;" context="_2" location="f1:7" file="f1" line="7" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Typedef id="_3" name="Int" type="_9" context="_1" access="private" location="f1:3" file="f1" line="3"/>
   <Method id="_4" name="method" returns="_9" context="_1" access="public" location="f1:5" file="f1" line="5">
     <Argument type="_3" location="f1:5" file="f1" line="5"/>
@@ -13,7 +13,7 @@
     <Argument type="_10" location="f1:7" file="f1" line="7"/>
   </OperatorMethod>
   <Destructor id="_8" name="start" context="_1" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1c"/>
   <ReferenceType id="_11" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-template-Method-Argument-default.xml.txt
+++ b/test/expect/gccxml.any.Class-template-Method-Argument-default.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:2" file="f1" line="2">
     <Argument type="_8" location="f1:2" file="f1" line="2" default="123"/>
   </Method>
@@ -12,7 +12,7 @@
     <Argument type="_9" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_8" name="int"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-template-friends.xml.txt
+++ b/test/expect/gccxml.any.Class-template-friends.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:8" file="f1" line="8" members="_3 _4 _5 _6" befriending="_7 _8"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:8" file="f1" line="8" members="_3 _4 _5 _6" befriending="_7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:8" file="f1" line="8" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:8" file="f1" line="8" inline="1" artificial="1"( throws="")?>
     <Argument type="_9" location="f1:8" file="f1" line="8"/>
@@ -17,6 +17,6 @@
   </Function>
   <Class id="_8" name="A&lt;int&gt;" context="_2" location="f1:1" file="f1" line="1" incomplete="1"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <FundamentalType id="_12" name="int"/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Class-template-friends.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Class-template-member-Typedef-const.xml.txt
+++ b/test/expect/gccxml.any.Class-template-member-Typedef-const.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8"/>
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Typedef id="_3" name="IntConst" type="_10c" context="_1" access="private" location="f1:2" file="f1" line="2"/>
   <Method id="_4" name="method" returns="_10c" context="_1" access="public" location="f1:4" file="f1" line="4">
     <Argument type="_3" location="f1:4" file="f1" line="4"/>
@@ -14,7 +14,7 @@
   </OperatorMethod>
   <Destructor id="_8" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throws="")?/>
   <CvQualifiedType id="_10c" type="_10" const="1"/>
-  <FundamentalType id="_10" name="int"/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_11" type="_1c"/>
   <ReferenceType id="_12" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-template-member-Typedef.xml.txt
+++ b/test/expect/gccxml.any.Class-template-member-Typedef.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Typedef id="_3" name="Int" type="_9" context="_1" access="private" location="f1:2" file="f1" line="2"/>
   <Method id="_4" name="method" returns="_9" context="_1" access="public" location="f1:4" file="f1" line="4">
     <Argument type="_3" location="f1:4" file="f1" line="4"/>
@@ -13,7 +13,7 @@
     <Argument type="_10" location="f1:6" file="f1" line="6"/>
   </OperatorMethod>
   <Destructor id="_8" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1c"/>
   <ReferenceType id="_11" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-template-member-template.xml.txt
+++ b/test/expect/gccxml.any.Class-template-member-template.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:2" file="f1" line="2" inline="1">
     <Argument type="_9" location="f1:2" file="f1" line="2"/>
   </Method>
@@ -12,8 +12,8 @@
     <Argument type="_10" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_8" name="int"/>
-  <FundamentalType id="_9" name="char"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="char" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1c"/>
   <ReferenceType id="_11" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Class-template.xml.txt
+++ b/test/expect/gccxml.any.Class-template.xml.txt
@@ -1,8 +1,8 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Class id="_1" name="start&lt;char&gt;" context="_4" location="f1:3" file="f1" line="3" incomplete="1"/>
-  <Class id="_2" name="start&lt;int&gt;" context="_4" location="f1:4" file="f1" line="4" members="_5 _6 _7 _8"/>
-  <Struct id="_3" name="start&lt;int &amp;&gt;" context="_4" location="f1:5" file="f1" line="5" members="_9 _10 _11 _12"/>
+  <Class id="_2" name="start&lt;int&gt;" context="_4" location="f1:4" file="f1" line="4" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_3" name="start&lt;int &amp;&gt;" context="_4" location="f1:5" file="f1" line="5" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_5" name="start" context="_2" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_6" name="start" context="_2" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throws="")?>
     <Argument type="_13" location="f1:4" file="f1" line="4"/>

--- a/test/expect/gccxml.any.Class.xml.txt
+++ b/test/expect/gccxml.any.Class.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_7" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.CvQualifiedType.xml.txt
+++ b/test/expect/gccxml.any.CvQualifiedType.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_3c" context="_4" location="f1:1" file="f1" line="1"/>
   <CvQualifiedType id="_3c" type="_3" const="1"/>
-  <FundamentalType id="_3" name="int"/>
+  <FundamentalType id="_3" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_4" name="::"/>
   <File id="f1" name=".*/test/input/CvQualifiedType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Field.xml.txt
+++ b/test/expect/gccxml.any.Field.xml.txt
@@ -1,9 +1,9 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9"/>
-  <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:2" file="f1" line="2"/>
-  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:3" file="f1" line="3"/>
-  <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" mutable="1"/>
+  <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
+  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:3" file="f1" line="3" offset="32"/>
+  <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64" mutable="1"/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
     <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>

--- a/test/expect/gccxml.any.Field.xml.txt
+++ b/test/expect/gccxml.any.Field.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:2" file="f1" line="2" offset="0"/>
   <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:3" file="f1" line="3" offset="32"/>
   <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64" mutable="1"/>
@@ -12,8 +12,8 @@
   </OperatorMethod>
   <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_10" name="int"/>
-  <FundamentalType id="_11" name="unsigned int"/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="unsigned int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_12" type="_1c"/>
   <ReferenceType id="_13" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Function-Argument-decay.xml.txt
+++ b/test/expect/gccxml.any.Function-Argument-decay.xml.txt
@@ -5,11 +5,11 @@
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
   </Function>
-  <FundamentalType id="_2" name="void"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_4" type="_6"/>
   <PointerType id="_5" type="_7"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int"/>
+  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
   <FunctionType id="_7" returns="_6">
     <Argument type="_6"/>
   </FunctionType>

--- a/test/expect/gccxml.any.Function-Argument-default.xml.txt
+++ b/test/expect/gccxml.any.Function-Argument-default.xml.txt
@@ -4,11 +4,11 @@
     <Argument type="_4" location="f1:1" file="f1" line="1" default="123"/>
     <Argument type="_5" location="f1:1" file="f1" line="1" default="&quot;abc&quot;"/>
   </Function>
-  <FundamentalType id="_2" name="void"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_5" type="_7c"/>
   <Namespace id="_3" name="::"/>
   <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <FundamentalType id="_7" name="char"/>
+  <FundamentalType id="_7" name="char" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Function-Argument-default.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Function-calling-convention-ms.xml.txt
+++ b/test/expect/gccxml.any.Function-calling-convention-ms.xml.txt
@@ -12,7 +12,7 @@
   <Function id="_4" name="start" returns="_5" context="_6" location="f1:4" file="f1" line="4" attributes="__thiscall__">
     <Argument type="_10" location="f1:4" file="f1" line="4"/>
   </Function>
-  <FundamentalType id="_5" name="void"/>
+  <FundamentalType id="_5" name="void" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_7" type="_11"/>
   <PointerType id="_8" type="_12"/>
   <PointerType id="_9" type="_13"/>

--- a/test/expect/gccxml.any.Function-rvalue-reference.xml.txt
+++ b/test/expect/gccxml.any.Function-rvalue-reference.xml.txt
@@ -3,7 +3,7 @@
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1">
     <Argument type="_2" location="f1:1" file="f1" line="1"/>
   </Function>
-  <FundamentalType id="_2" name="int"/>
+  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Function-rvalue-reference.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Function-template.xml.txt
+++ b/test/expect/gccxml.any.Function-template.xml.txt
@@ -6,8 +6,8 @@
   <Function id="_2" name="start" returns="_5" context="_4" location="f1:1" file="f1" line="1">
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
   </Function>
-  <FundamentalType id="_3" name="char"/>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_3" name="char" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_4" name="::"/>
   <File id="f1" name=".*/test/input/Function-template.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Function-throw.xml.txt
+++ b/test/expect/gccxml.any.Function-throw.xml.txt
@@ -3,9 +3,9 @@
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" throws="_4 _5">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
   </Function>
-  <FundamentalType id="_2" name="void"/>
-  <FundamentalType id="_4" name="int"/>
-  <FundamentalType id="_5" name="char"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_5" name="char" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Function-throw.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Function-variadic.xml.txt
+++ b/test/expect/gccxml.any.Function-variadic.xml.txt
@@ -4,8 +4,8 @@
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Ellipsis/>
   </Function>
-  <FundamentalType id="_2" name="void"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Function-variadic.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Function.xml.txt
+++ b/test/expect/gccxml.any.Function.xml.txt
@@ -3,8 +3,8 @@
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
   </Function>
-  <FundamentalType id="_2" name="void"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Function.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.FunctionType-variadic.xml.txt
+++ b/test/expect/gccxml.any.FunctionType-variadic.xml.txt
@@ -5,8 +5,8 @@
     <Argument type="_5"/>
     <Ellipsis/>
   </FunctionType>
-  <FundamentalType id="_4" name="void"/>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_4" name="void" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/FunctionType-variadic.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.FunctionType.xml.txt
+++ b/test/expect/gccxml.any.FunctionType.xml.txt
@@ -4,8 +4,8 @@
   <FunctionType id="_2" returns="_4">
     <Argument type="_5"/>
   </FunctionType>
-  <FundamentalType id="_4" name="void"/>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_4" name="void" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/FunctionType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.FundamentalType.xml.txt
+++ b/test/expect/gccxml.any.FundamentalType.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="int"/>
+  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/FundamentalType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.FundamentalTypes.xml.txt
+++ b/test/expect/gccxml.any.FundamentalTypes.xml.txt
@@ -14,19 +14,19 @@
   <Typedef id="_13" name="t_ULongLong" type="_26" context="_1" location="f1:12" file="f1" line="12"/>
   <Typedef id="_14" name="t_Float" type="_27" context="_1" location="f1:13" file="f1" line="13"/>
   <Typedef id="_15" name="t_Double" type="_28" context="_1" location="f1:14" file="f1" line="14"/>
-  <FundamentalType id="_16" name="char"/>
-  <FundamentalType id="_17" name="signed char"/>
-  <FundamentalType id="_18" name="unsigned char"/>
-  <FundamentalType id="_19" name="short int"/>
-  <FundamentalType id="_20" name="short unsigned int"/>
-  <FundamentalType id="_21" name="int"/>
-  <FundamentalType id="_22" name="unsigned int"/>
-  <FundamentalType id="_23" name="long int"/>
-  <FundamentalType id="_24" name="long unsigned int"/>
-  <FundamentalType id="_25" name="long long int"/>
-  <FundamentalType id="_26" name="long long unsigned int"/>
-  <FundamentalType id="_27" name="float"/>
-  <FundamentalType id="_28" name="double"/>
+  <FundamentalType id="_16" name="char" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_17" name="signed char" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_18" name="unsigned char" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_19" name="short int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_20" name="short unsigned int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_21" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_22" name="unsigned int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_23" name="long int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_24" name="long unsigned int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_25" name="long long int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_26" name="long long unsigned int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_27" name="float" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_28" name="double" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/FundamentalTypes.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.GNU-float128.xml.txt
+++ b/test/expect/gccxml.any.GNU-float128.xml.txt
@@ -17,7 +17,7 @@
   <ArrayType id="_10" min="0" max="15" type="_13"/>
   <ReferenceType id="_11" type="_4c"/>
   <ReferenceType id="_12" type="_4"/>
-  <FundamentalType id="_13" name="char"/>
+  <FundamentalType id="_13" name="char" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <CvQualifiedType id="_4c" type="_4" const="1"/>
   <File id="f0" name="&lt;builtin&gt;"/>

--- a/test/expect/gccxml.any.Method-rvalue-reference.xml.txt
+++ b/test/expect/gccxml.any.Method-rvalue-reference.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:2" file="f1" line="2">
     <Argument type="_7" location="f1:2" file="f1" line="2"/>
   </Constructor>
@@ -12,7 +12,7 @@
   </Method>
   <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <ReferenceType id="_7" type="_1"/>
-  <FundamentalType id="_8" name="int"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-rvalue-reference.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Method.xml.txt
+++ b/test/expect/gccxml.any.Method.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:2" file="f1" line="2">
     <Argument type="_8" location="f1:2" file="f1" line="2"/>
   </Method>
@@ -12,7 +12,7 @@
     <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_8" name="int"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.MethodType-cv.xml.txt
+++ b/test/expect/gccxml.any.MethodType-cv.xml.txt
@@ -8,6 +8,6 @@
     <Argument type="_7"/>
   </MethodType>
   <Class id="_6" name="A" context="_4" location="f1:1" file="f1" line="1" incomplete="1"/>
-  <FundamentalType id="_7" name="int"/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/MethodType-cv.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.MethodType.xml.txt
+++ b/test/expect/gccxml.any.MethodType.xml.txt
@@ -7,6 +7,6 @@
     <Argument type="_6"/>
   </MethodType>
   <Class id="_5" name="A" context="_3" location="f1:1" file="f1" line="1" incomplete="1"/>
-  <FundamentalType id="_6" name="int"/>
+  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/MethodType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Namespace-Class-members.xml.txt
+++ b/test/expect/gccxml.any.Namespace-Class-members.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Namespace id="_1" name="start" context="_2" members="_3"/>
-  <Class id="_3" name="A" context="_1" location="f1:2" file="f1" line="2" members="_4 _5 _6 _7 _8"/>
+  <Class id="_3" name="A" context="_1" location="f1:2" file="f1" line="2" members="_4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Variable id="_4" name="data" type="_9" context="_3" access="private" location="f1:3" file="f1" line="3" static="1"/>
   <Constructor id="_5" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_6" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throws="")?>
@@ -11,7 +11,7 @@
     <Argument type="_10" location="f1:2" file="f1" line="2"/>
   </OperatorMethod>
   <Destructor id="_8" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_3c"/>
   <ReferenceType id="_11" type="_3"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Namespace-extern-C-members.xml.txt
+++ b/test/expect/gccxml.any.Namespace-extern-C-members.xml.txt
@@ -5,7 +5,7 @@
   <Function id="_4" name="function" returns="_3" context="_1" location="f1:4" file="f1" line="4">
     <Argument type="_3" location="f1:4" file="f1" line="4"/>
   </Function>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Namespace-extern-C-members.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Namespace-repeat-start.xml.txt
+++ b/test/expect/gccxml.any.Namespace-repeat-start.xml.txt
@@ -3,7 +3,7 @@
   <Namespace id="_1" name="start" context="_2" members="_3 _4"/>
   <Function id="_3" name="f1" returns="_5" context="_1" location="f1:2" file="f1" line="2"/>
   <Function id="_4" name="f2" returns="_5" context="_1" location="f1:5" file="f1" line="5"/>
-  <FundamentalType id="_5" name="void"/>
+  <FundamentalType id="_5" name="void" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Namespace-repeat-start.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Namespace-repeat.xml.txt
+++ b/test/expect/gccxml.any.Namespace-repeat.xml.txt
@@ -4,7 +4,7 @@
   <Namespace id="_3" name="ns" context="_1" members="_4 _5"/>
   <Function id="_4" name="f1" returns="_6" context="_3" location="f1:3" file="f1" line="3"/>
   <Function id="_5" name="f2" returns="_6" context="_3" location="f1:6" file="f1" line="6"/>
-  <FundamentalType id="_6" name="void"/>
+  <FundamentalType id="_6" name="void" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Namespace-repeat.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.OffsetType-cv.xml.txt
+++ b/test/expect/gccxml.any.OffsetType-cv.xml.txt
@@ -5,7 +5,7 @@
   <OffsetType id="_3" basetype="_5" type="_7cv"/>
   <Class id="_5" name="A" context="_4" location="f1:1" file="f1" line="1" incomplete="1"/>
   <CvQualifiedType id="_7cv" type="_7" const="1" volatile="1"/>
-  <FundamentalType id="_7" name="int"/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_4" name="::"/>
   <File id="f1" name=".*/test/input/OffsetType-cv.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.OffsetType.xml.txt
+++ b/test/expect/gccxml.any.OffsetType.xml.txt
@@ -3,7 +3,7 @@
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:2" file="f1" line="2"/>
   <OffsetType id="_2" basetype="_4" type="_5"/>
   <Class id="_4" name="A" context="_3" location="f1:1" file="f1" line="1" incomplete="1"/>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/OffsetType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.OperatorFunction.xml.txt
+++ b/test/expect/gccxml.any.OperatorFunction.xml.txt
@@ -6,7 +6,7 @@
     <Argument type="_5" location="f1:3" file="f1" line="3"/>
   </OperatorFunction>
   <ReferenceType id="_4" type="_6"/>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <Class id="_6" name="A" context="_2" location="f1:1" file="f1" line="1" incomplete="1"/>
   <File id="f1" name=".*/test/input/OperatorFunction.cxx"/>

--- a/test/expect/gccxml.any.OperatorMethod.xml.txt
+++ b/test/expect/gccxml.any.OperatorMethod.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:2" file="f1" line="2">
     <Argument type="_9" location="f1:2" file="f1" line="2"/>
   </OperatorMethod>
@@ -13,7 +13,7 @@
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <ReferenceType id="_8" type="_1"/>
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1c"/>
   <Namespace id="_2" name="::"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>

--- a/test/expect/gccxml.any.PointerType.xml.txt
+++ b/test/expect/gccxml.any.PointerType.xml.txt
@@ -3,6 +3,6 @@
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
   <PointerType id="_2" type="_4"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/PointerType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.ReferenceType.xml.txt
+++ b/test/expect/gccxml.any.ReferenceType.xml.txt
@@ -3,6 +3,6 @@
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
   <ReferenceType id="_2" type="_4"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/ReferenceType.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Typedef-paren.xml.txt
+++ b/test/expect/gccxml.any.Typedef-paren.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="int"/>
+  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Typedef-paren.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Typedef-to-FundamentalType-mode.xml.txt
+++ b/test/expect/gccxml.any.Typedef-to-FundamentalType-mode.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="short int"/>
+  <FundamentalType id="_2" name="short int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Typedef-to-FundamentalType-mode.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Typedef-to-extern-C-FundamentalType-mode.xml.txt
+++ b/test/expect/gccxml.any.Typedef-to-extern-C-FundamentalType-mode.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:2" file="f1" line="2"/>
-  <FundamentalType id="_2" name="short int"/>
+  <FundamentalType id="_2" name="short int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Typedef-to-extern-C-FundamentalType-mode.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Variable-in-Class.xml.txt
+++ b/test/expect/gccxml.any.Variable-in-Class.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
   <Variable id="_3" name="static_field" type="_8" context="_1" access="private" location="f1:2" file="f1" line="2" static="1"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?>
@@ -10,7 +10,7 @@
     <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>
-  <FundamentalType id="_8" name="int"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
   <Namespace id="_2" name="::"/>

--- a/test/expect/gccxml.any.Variable-init.xml.txt
+++ b/test/expect/gccxml.any.Variable-init.xml.txt
@@ -3,10 +3,10 @@
   <Namespace id="_1" name="start" context="_2" members="_3 _4"/>
   <Variable id="_3" name="var_int" type="_5" init="123" context="_1" location="f1:2" file="f1" line="2"/>
   <Variable id="_4" name="var_str" type="_6" init="&quot;abc&quot;" context="_1" location="f1:3" file="f1" line="3"/>
-  <FundamentalType id="_5" name="int"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_6" type="_8c"/>
   <Namespace id="_2" name="::"/>
   <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <FundamentalType id="_8" name="char"/>
+  <FundamentalType id="_8" name="char" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Variable-init.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Variable.xml.txt
+++ b/test/expect/gccxml.any.Variable.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Variable id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="int"/>
+  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Variable.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.implicit-decl-ms.xml.txt
+++ b/test/expect/gccxml.any.implicit-decl-ms.xml.txt
@@ -4,7 +4,7 @@
     <Argument type="_2" location="f1:1" file="f1" line="1"/>
   </Function>
   <Typedef id="_2" name="size_t" type="_4" context="_3" location="f0:0" file="f0" line="0"/>
-  <FundamentalType id="_4" name="unsigned int"/>
+  <FundamentalType id="_4" name="unsigned int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f0" name="&lt;builtin&gt;"/>
   <File id="f1" name=".*/test/input/implicit-decl-ms.cxx"/>

--- a/test/expect/gccxml.any.inline-asm-ms.xml.txt
+++ b/test/expect/gccxml.any.inline-asm-ms.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="void"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/inline-asm-ms.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.qualified-type-name.xml.txt
+++ b/test/expect/gccxml.any.qualified-type-name.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:2" file="f1" line="2"/>
   <Typedef id="_2" name="type" type="_4" context="_5" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <Namespace id="_5" name="ns" context="_3"/>
   <File id="f1" name=".*/test/input/qualified-type-name.cxx"/>

--- a/test/expect/gccxml.any.using-declaration-class.xml.txt
+++ b/test/expect/gccxml.any.using-declaration-class.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8" bases="_9">
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8" bases="_9" size="[0-9]+" align="[0-9]+">
     <Base type="_9" access="public" virtual="0"/>
   </Class>
   <Method id="_3" name="f" returns="_10" context="_9" access="protected" location="f1:3" file="f1" line="3">
@@ -17,9 +17,9 @@
     <Argument type="_12" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
   <Destructor id="_8" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throws="")?/>
-  <Class id="_9" name="base" context="_2" location="f1:1" file="f1" line="1" members="_3 _14 _15 _16 _17"/>
-  <FundamentalType id="_10" name="int"/>
-  <FundamentalType id="_11" name="char"/>
+  <Class id="_9" name="base" context="_2" location="f1:1" file="f1" line="1" members="_3 _14 _15 _16 _17" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="char" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_12" type="_1c"/>
   <ReferenceType id="_13" type="_1"/>
   <Constructor id="_14" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>

--- a/test/expect/gccxml.broken.any.Class-template-constructor-template.xml.txt
+++ b/test/expect/gccxml.broken.any.Class-template-constructor-template.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:3" file="f1" line="3">
     <Argument type="_7" location="f1:3" file="f1" line="3"/>
   </Constructor>

--- a/test/expect/gccxml.broken.any.ReferenceType-to-Class-template.xml.txt
+++ b/test/expect/gccxml.broken.any.ReferenceType-to-Class-template.xml.txt
@@ -12,13 +12,13 @@
     <Argument type="_10" location="f1:4" file="f1" line="4"/>
     <Argument type="_11" location="f1:4" file="f1" line="4"/>
   </Function>
-  <FundamentalType id="_4" name="void"/>
+  <FundamentalType id="_4" name="void" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_6" type="_12"/>
-  <FundamentalType id="_7" name="short int"/>
+  <FundamentalType id="_7" name="short int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_8" type="_12"/>(broken: duplicate ReferenceType)?
-  <FundamentalType id="_9" name="int"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_12"/>(broken: duplicate ReferenceType)?
-  <FundamentalType id="_11" name="long int"/>
+  <FundamentalType id="_11" name="long int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_5" name="::"/>
   <Class id="_12" name="A&lt;int&gt;" context="_5" location="f1:1" file="f1" line="1" incomplete="1"/>
   <File id="f1" name=".*/test/input/ReferenceType-to-Class-template.cxx"/>

--- a/test/expect/gccxml.c++11.Class-bases.xml.txt
+++ b/test/expect/gccxml.c++11.Class-bases.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9">
+  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9" size="[0-9]+" align="[0-9]+">
     <Base type="_7" access="public" virtual="0"/>
     <Base type="_8" access="private" virtual="0"/>
     <Base type="_9" access="protected" virtual="1"/>
@@ -13,9 +13,9 @@
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1">
     <Argument type="_11" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15"/>
-  <Class id="_8" name="base_private" context="_2" location="f1:2" file="f1" line="2" members="_16 _17 _18 _19"/>
-  <Class id="_9" name="base_protected" context="_2" location="f1:3" file="f1" line="3" members="_20 _21 _22 _23"/>
+  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_8" name="base_private" context="_2" location="f1:2" file="f1" line="2" members="_16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_9" name="base_protected" context="_2" location="f1:3" file="f1" line="3" members="_20 _21 _22 _23" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1"/>
   <ReferenceType id="_11" type="_1c"/>
   <OperatorMethod id="_12" name="=" returns="_25" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">

--- a/test/expect/gccxml.c++11.Class-template-bases.xml.txt
+++ b/test/expect/gccxml.c++11.Class-template-bases.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 _8">
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 _8" size="[0-9]+" align="[0-9]+">
     <Base type="_7" access="public" virtual="0"/>
     <Base type="_8" access="public" virtual="0"/>
   </Class>
@@ -12,8 +12,8 @@
     <Argument type="_9" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
   <Destructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14"/>
-  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_15 _16 _17 _18"/>
+  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
   <Constructor id="_11" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>

--- a/test/expect/gccxml.c++98.Class-bases.xml.txt
+++ b/test/expect/gccxml.c++98.Class-bases.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9">
+  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9" size="[0-9]+" align="[0-9]+">
     <Base type="_7" access="public" virtual="0"/>
     <Base type="_8" access="private" virtual="0"/>
     <Base type="_9" access="protected" virtual="1"/>
@@ -13,9 +13,9 @@
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1" throws="">
     <Argument type="_11" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15"/>
-  <Class id="_8" name="base_private" context="_2" location="f1:2" file="f1" line="2" members="_16 _17 _18 _19"/>
-  <Class id="_9" name="base_protected" context="_2" location="f1:3" file="f1" line="3" members="_20 _21 _22 _23"/>
+  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_8" name="base_private" context="_2" location="f1:2" file="f1" line="2" members="_16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_9" name="base_protected" context="_2" location="f1:3" file="f1" line="3" members="_20 _21 _22 _23" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_10" type="_1"/>
   <ReferenceType id="_11" type="_1c"/>
   <Constructor id="_12" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" throws=""/>

--- a/test/expect/gccxml.c++98.Class-template-bases.xml.txt
+++ b/test/expect/gccxml.c++98.Class-template-bases.xml.txt
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 _8">
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" bases="_7 _8" size="[0-9]+" align="[0-9]+">
     <Base type="_7" access="public" virtual="0"/>
     <Base type="_8" access="public" virtual="0"/>
   </Class>
@@ -12,8 +12,8 @@
     <Argument type="_9" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
   <Destructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throws="")?/>
-  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14"/>
-  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_15 _16 _17 _18"/>
+  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_9" type="_1c"/>
   <ReferenceType id="_10" type="_1"/>
   <Constructor id="_11" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throws="")?/>

--- a/test/expect/gccxml.c89.FunctionNoProto.xml.txt
+++ b/test/expect/gccxml.c89.FunctionNoProto.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="int"/>
+  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/FunctionNoProto.c"/>
 </GCC_XML>$

--- a/test/expect/gccxml.c89.FundamentalType.xml.txt
+++ b/test/expect/gccxml.c89.FundamentalType.xml.txt
@@ -1,7 +1,7 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_2" name="int"/>
+  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/FundamentalType.c"/>
 </GCC_XML>$

--- a/test/expect/gccxml.c89.Typedef-called-class.xml.txt
+++ b/test/expect/gccxml.c89.Typedef-called-class.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:2" file="f1" line="2"/>
   <Typedef id="_2" name="class" type="_4" context="_3" location="f1:1" file="f1" line="1"/>
-  <FundamentalType id="_4" name="int"/>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Typedef-called-class.c"/>
 </GCC_XML>$


### PR DESCRIPTION
This is expected by pygccxml, at least for the first batch of tests I am currently fixing.

Maybe align and size attributes will need to be added to other declarations later, I did only cover these two (RecordDecl and BuiltinType) for the moment.