### PR TITLE
WIP: Hide inline and anonymous namespaces

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -22,10 +22,11 @@
 
 struct Options
 {
-  Options(): PPOnly(false), GccXml(false), HaveCC(false) {}
+  Options(): PPOnly(false), GccXml(false), HaveCC(false), HideInlineNameSpaces(false) {}
   bool PPOnly;
   bool GccXml;
   bool HaveCC;
+  bool HideInlineNameSpaces;
   struct Include {
     Include(std::string const& d, bool f = false):
       Directory(d), Framework(f) {}

--- a/src/castxml.cxx
+++ b/src/castxml.cxx
@@ -94,6 +94,11 @@ int main(int argc_in, const char** argv_in)
     "  --castxml-start <name>\n"
     "    Start AST traversal at declaration with given (qualified) name\n"
     "\n"
+    "  --hide-inline-namespaces\n"
+    "    Do not display inline and anonymous namespaces.\n"
+    "    Example: std::__1 with libc++ will look the same as the\n"
+    "    libstdc++ namespace std."
+    "\n"
     "  -help, --help\n"
     "    Print castxml and internal Clang compiler usage information\n"
     "\n"
@@ -193,6 +198,8 @@ int main(int argc_in, const char** argv_in)
           ;
         return 1;
       }
+    } else if(strcmp(argv[i], "--hide-inline-namespaces") == 0) {
+      opts.HideInlineNameSpaces = true;
     } else if(strcmp(argv[i], "-E") == 0) {
       opts.PPOnly = true;
     } else if(strcmp(argv[i], "-o") == 0) {


### PR DESCRIPTION
Hi. This is a an attempt to hide inline namespaces (especially std::__1 with libc++), as this is often not needed (for example in pygccxml).

There are two problems I stumbled upon:

- The Variable tag has an "init" attribute, and even by correctly setting the printing policy, the attribute still contains ::__1
- Most importantly, the ```<Namespace name="__1"``` is still there for the moment. It needs to be merged with the ```std``` namespace, but for this I need to re-order the ids of the nodes in Output.cxx, which I was not able to do correctly. I found the isInlineNamespace() method which can be used on declarations; and using the parent declaration context one can check for isStdNamespace().