### PR TITLE
ENH: Add parsing of comma separated list for --castxml-start option

### DIFF
--- a/doc/manual/castxml.1.rst
+++ b/doc/manual/castxml.1.rst
@@ -56,8 +56,10 @@ Remaining options are given to the internal Clang compiler.
   ``<Unimplemented/>`` elements on non-c++98 constructs.
 
 ``--castxml-start <name>``
-  Start AST traversal at the declaration(s) with the given
-  qualified name.
+  Start AST traversal at the declaration(s) with the given qualified name.
+  A list of comma-separated declarations can be used for multiple
+  starting declarations, or the --castxml-start flag can be used multiple
+  times.
 
 ``-help``, ``--help``
   Print ``castxml`` and internal Clang compiler usage information.

--- a/src/castxml.cxx
+++ b/src/castxml.cxx
@@ -27,6 +27,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <iostream>
+#include <sstream>
 #include <set>
 #include <system_error>
 #include <vector>
@@ -92,7 +93,10 @@ int main(int argc_in, const char** argv_in)
     "    Write gccxml-format output to <src>.xml or file named by '-o'\n"
     "\n"
     "  --castxml-start <name>\n"
-    "    Start AST traversal at declaration with given (qualified) name\n"
+    "    Start AST traversal at declaration(s) with given (qualified) name\n"
+    "    A list of comma-separated declarations can be used for multiple\n"
+    "    starting declarations, or the --castxml-start flag can be used\n"
+    "    multiple times.\n"
     "\n"
     "  -help, --help\n"
     "    Print castxml and internal Clang compiler usage information\n"
@@ -124,7 +128,12 @@ int main(int argc_in, const char** argv_in)
       }
     } else if(strcmp(argv[i], "--castxml-start") == 0) {
       if((i+1) < argc) {
-        opts.StartNames.push_back(argv[++i]);
+        char delim[] = ",";
+        std::string item;
+        std::stringstream stream(argv[++i]);
+        while(std::getline(stream, item, delim[0])) {
+          opts.StartNames.push_back(item);
+        }
       } else {
         std::cerr <<
           "error: argument to '--castxml-start' is missing "

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,9 +33,9 @@ macro(castxml_test_cmd test)
     )
 endmacro()
 
-macro(castxml_test_gccxml_common prefix ext std test)
+macro(castxml_test_gccxml_common prefix ext std test start)
   set(command $<TARGET_FILE:castxml>
-    --castxml-gccxml --castxml-start start
+    --castxml-gccxml ${start}
     -std=${std}
     ${CMAKE_CURRENT_LIST_DIR}/input/${test}.${ext}
     -o ${prefix}.${std}.${test}.xml
@@ -53,23 +53,28 @@ macro(castxml_test_gccxml_common prefix ext std test)
 endmacro()
 
 macro(castxml_test_gccxml_c89 test)
-  castxml_test_gccxml_common(gccxml c c89 ${test})
+  set(start --castxml-start start)
+  castxml_test_gccxml_common(gccxml c c89 ${test} "${start}")
 endmacro()
 
 macro(castxml_test_gccxml_cxx98 test)
-  castxml_test_gccxml_common(gccxml cxx c++98 ${test})
+  set(start --castxml-start start)
+  castxml_test_gccxml_common(gccxml cxx c++98 ${test} "${start}")
 endmacro()
 
 macro(castxml_test_gccxml_cxx11 test)
-  castxml_test_gccxml_common(gccxml cxx c++11 ${test})
+  set(start --castxml-start start)
+  castxml_test_gccxml_common(gccxml cxx c++11 ${test} "${start}")
 endmacro()
 
 macro(castxml_test_gccxml_broken_cxx98 test)
-  castxml_test_gccxml_common(gccxml.broken cxx c++98 ${test})
+  set(start --castxml-start start)
+  castxml_test_gccxml_common(gccxml.broken cxx c++98 ${test} "${start}")
 endmacro()
 
 macro(castxml_test_gccxml_broken_cxx11 test)
-  castxml_test_gccxml_common(gccxml.broken cxx c++11 ${test})
+  set(start --castxml-start start)
+  castxml_test_gccxml_common(gccxml.broken cxx c++11 ${test} "${start}")
 endmacro()
 
 macro(castxml_test_gccxml_c test)
@@ -79,6 +84,13 @@ endmacro()
 macro(castxml_test_gccxml test)
   castxml_test_gccxml_cxx98(${test})
   castxml_test_gccxml_cxx11(${test})
+endmacro()
+
+macro(castxml_test_gccxml_multiple)
+  set(start "--castxml-start;start::ns1,start::ns3")
+  castxml_test_gccxml_common(multiple1 cxx c++11 Multiple-Starts "${start}")
+  set(start "--castxml-start;start::ns1;--castxml-start;start::ns3")
+  castxml_test_gccxml_common(multiple2 cxx c++11 Multiple-Starts "${start}")
 endmacro()
 
 macro(castxml_test_gccxml_broken test)
@@ -91,6 +103,8 @@ set(empty_c ${input}/empty.c)
 set(empty_cxx ${input}/empty.cxx)
 set(empty_m ${input}/empty.m)
 set(empty_mm ${input}/empty.mm)
+
+castxml_test_gccxml_multiple()
 
 castxml_test_cmd(help1 -help)
 castxml_test_cmd(help2 --help)

--- a/test/expect/multiple1.any.Multiple-Starts.xml.txt
+++ b/test/expect/multiple1.any.Multiple-Starts.xml.txt
@@ -1,0 +1,11 @@
+^<\?xml version="1.0"\?>
+<GCC_XML[^>]*>
+  <Namespace id="_1" name="ns1" context="_3" members="_4"/>
+  <Namespace id="_2" name="ns3" context="_3" members="_5"/>
+  <Function id="_4" name="f1" returns="_6" context="_1" location="f1:3" file="f1" line="3" mangled="[^"]+"/>
+  <Function id="_5" name="f3" returns="_6" context="_2" location="f1:9" file="f1" line="9" mangled="[^"]+"/>
+  <FundamentalType id="_6" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="start" context="_7"/>
+  <Namespace id="_7" name="::"/>
+  <File id="f1" name=".*/test/input/Multiple-Starts.cxx"/>
+</GCC_XML>$

--- a/test/expect/multiple2.any.Multiple-Starts.xml.txt
+++ b/test/expect/multiple2.any.Multiple-Starts.xml.txt
@@ -1,0 +1,11 @@
+^<\?xml version="1.0"\?>
+<GCC_XML[^>]*>
+  <Namespace id="_1" name="ns1" context="_3" members="_4"/>
+  <Namespace id="_2" name="ns3" context="_3" members="_5"/>
+  <Function id="_4" name="f1" returns="_6" context="_1" location="f1:3" file="f1" line="3" mangled="[^"]+"/>
+  <Function id="_5" name="f3" returns="_6" context="_2" location="f1:9" file="f1" line="9" mangled="[^"]+"/>
+  <FundamentalType id="_6" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="start" context="_7"/>
+  <Namespace id="_7" name="::"/>
+  <File id="f1" name=".*/test/input/Multiple-Starts.cxx"/>
+</GCC_XML>$

--- a/test/input/Multiple-Starts.cxx
+++ b/test/input/Multiple-Starts.cxx
@@ -1,0 +1,11 @@
+namespace start {
+  namespace ns1 {
+    void f1();
+  }
+  namespace ns2 {
+    void f2();
+  }
+  namespace ns3 {
+    void f3();
+  }
+}


### PR DESCRIPTION
In gccxml one could input a comma-separated list for the starting declarations
to parse. The infrastructure is already there in castxml as there is a for loop on
opts.StartNames; but the inputed option was never parsed split.