### PR TITLE
Output: Update `cvs_revision` number to indicate output change

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -2104,7 +2104,7 @@ void ASTVisitor::HandleTranslationUnit(clang::TranslationUnitDecl const* tu)
   // Start dump with gccxml-compatible format.
   this->OS <<
     "<?xml version=\"1.0\"?>\n"
-    "<GCC_XML version=\"0.9.0\" cvs_revision=\"1.137\">\n"
+    "<GCC_XML version=\"0.9.0\" cvs_revision=\"1.138\">\n"
     ;
 
   // Dump the complete nodes.


### PR DESCRIPTION
Update the file format revision number so tools can distinguish
the new content from that produced by older CastXML versions.

GitHub-Issues: CastXML/CastXML#52, CastXML/CastXML#55, CastXML/CastXML#56