### PR TITLE
Fix assertion on using getName() parsing builtin string header

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -812,7 +812,7 @@ void ASTVisitor::AddDeclContextMembers(clang::DeclContext const* dc,
     // Skip declarations that we use internally as builtins.
     if (isTranslationUnit) {
       if (clang::NamedDecl const* nd = clang::dyn_cast<clang::NamedDecl>(d)) {
-        if (nd->getName().find("__castxml") != std::string::npos) {
+        if (nd->getNameAsString().find("__castxml") != std::string::npos) {
           continue;
         }
       }


### PR DESCRIPTION
This intends to fix issue #62 
Trying the same command line I used in the description of the issue, the assertion is no longer shown.