### PR TITLE
Output (multi-dimensional) array information for array parameters

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -438,6 +438,9 @@ class ASTVisitor : public ASTVisitorBase
       declaration's attributes.  */
   void PrintAttributesAttribute(clang::Decl const* d);
 
+  /** Print an array tag with (multi-dimensional) size information.  */
+  void PrintArrayType(clang::ArrayType const* t, DumpNode const* dn, uint64_t const size = 0);
+
   /** Get the attributes of the given function type.  */
   void GetFunctionTypeAttributes(clang::FunctionProtoType const* t,
                                  std::vector<std::string>& attrs);
@@ -1670,7 +1673,17 @@ void ASTVisitor::OutputFunctionArgument(clang::ParmVarDecl const* a,
   if (!name.empty()) {
     this->PrintNameAttribute(name);
   }
-  this->PrintTypeAttribute(a->getType(), complete);
+
+  clang::QualType originalType = a->getOriginalType();
+  if (originalType.getTypePtr()->isArrayType())
+  {
+    this->PrintTypeAttribute(originalType, complete);
+  }
+  else
+  {
+    this->PrintTypeAttribute(a->getType(), complete);
+  }
+
   this->PrintLocationAttribute(a);
   if (def) {
     this->OS << " default=\"";
@@ -2095,24 +2108,56 @@ void ASTVisitor::OutputBuiltinType(clang::BuiltinType const* t,
   this->OS << "/>\n";
 }
 
-void ASTVisitor::OutputConstantArrayType(clang::ConstantArrayType const* t,
-                                         DumpNode const* dn)
+void ASTVisitor::PrintArrayType(clang::ArrayType const* t, DumpNode const* dn, uint64_t const size)
 {
   this->OS << "  <ArrayType";
   this->PrintIdAttribute(dn);
-  this->OS << " min=\"0\" max=\"" << (t->getSize() - 1) << "\"";
-  this->PrintTypeAttribute(t->getElementType(), dn->Complete);
-  this->OS << "/>\n";
+  this->OS << " min=\"0\" max=\"";
+  if (size > 0) {
+    this->OS << (size - 1);
+  }
+  this->OS << "\"";
+  clang::QualType elementType = t->getElementType();
+
+  //collect multi-dimensional array sizes
+  std::vector<int> dimensions;
+  dimensions.push_back(size);
+
+  clang::Type const *subType = elementType.getTypePtr();
+  while (subType->isArrayType())
+  {
+    clang::ConstantArrayType const* cat = clang::dyn_cast<clang::ConstantArrayType>(subType);
+    dimensions.push_back(cat->getSize().getLimitedValue());
+
+    elementType = clang::dyn_cast<clang::ArrayType>(subType)->getElementType();
+    subType = elementType.getTypePtr();
+  } 
+
+  this->PrintTypeAttribute(elementType, dn->Complete);
+  this->OS << ">\n";
+
+  for (std::vector<int>::const_iterator i = dimensions.begin(), e = dimensions.end(); i != e; ++i)
+  {
+    this->OS << "    <Size>";
+    if (*i > 0) {
+      this->OS << (*i);
+    }
+    this->OS << "</Size>\n";
+  }
+
+  this->OS << "  </ArrayType>\n";
+}
+
+void ASTVisitor::OutputConstantArrayType(clang::ConstantArrayType const* t,
+                                         DumpNode const* dn)
+{
+  PrintArrayType(t, dn, t->getSize().getLimitedValue());
 }
 
 void ASTVisitor::OutputIncompleteArrayType(clang::IncompleteArrayType const* t,
                                            DumpNode const* dn)
 {
-  this->OS << "  <ArrayType";
-  this->PrintIdAttribute(dn);
-  this->OS << " min=\"0\" max=\"\"";
-  this->PrintTypeAttribute(t->getElementType(), dn->Complete);
-  this->OS << "/>\n";
+  PrintArrayType(t, dn);
 }
 
 void ASTVisitor::OutputFunctionProtoType(clang::FunctionProtoType const* t,

--- a/test/expect/castxml1.any.ArrayType-incomplete.xml.txt
+++ b/test/expect/castxml1.any.ArrayType-incomplete.xml.txt
@@ -1,7 +1,9 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <ArrayType id="_2" min="0" max="" type="_4"/>
+  <ArrayType id="_2" min="0" max="" type="_4">
+    <Size></Size>
+  </ArrayType>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/ArrayType-incomplete.cxx"/>

--- a/test/expect/castxml1.any.ArrayType.xml.txt
+++ b/test/expect/castxml1.any.ArrayType.xml.txt
@@ -1,7 +1,9 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <ArrayType id="_2" min="0" max="1" type="_4"/>
+  <ArrayType id="_2" min="0" max="1" type="_4">
+    <Size>2</Size>
+  </ArrayType>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/ArrayType.cxx"/>

--- a/test/expect/castxml1.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-array.xml.txt
@@ -10,7 +10,9 @@
     <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ArrayType id="_8" min="0" max="1" type="_11"/>
+  <ArrayType id="_8" min="0" max="1" type="_11">
+    <Size>2</Size>
+  </ArrayType>
   <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>

--- a/test/expect/castxml1.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-array.xml.txt
@@ -1,22 +1,27 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_9" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Field id="_4" name="data2D" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ArrayType id="_8" min="0" max="1" type="_11">
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ArrayType id="_9" min="0" max="1" type="_13">
     <Size>2</Size>
   </ArrayType>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_10" min="0" max="" type="_13">
+    <Size></Size>
+    <Size>6</Size>
+  </ArrayType>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_13" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-array.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Function-Argument-decay.xml.txt
+++ b/test/expect/castxml1.any.Function-Argument-decay.xml.txt
@@ -2,16 +2,21 @@
 <CastXML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_6" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_4" min="0" max="1" type="_7">
+    <Size>2</Size>
+  </ArrayType>
+  <ArrayType id="_5" min="0" max="" type="_7">
+    <Size></Size>
+  </ArrayType>
+  <PointerType id="_6" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_7" returns="_6">
-    <Argument type="_6"/>
+  <FunctionType id="_8" returns="_7">
+    <Argument type="_7"/>
   </FunctionType>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </CastXML>$

--- a/test/expect/gccxml.any.ArrayType-incomplete.xml.txt
+++ b/test/expect/gccxml.any.ArrayType-incomplete.xml.txt
@@ -1,7 +1,9 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <ArrayType id="_2" min="0" max="" type="_4"/>
+  <ArrayType id="_2" min="0" max="" type="_4">
+    <Size></Size>
+  </ArrayType>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/ArrayType-incomplete.cxx"/>

--- a/test/expect/gccxml.any.ArrayType.xml.txt
+++ b/test/expect/gccxml.any.ArrayType.xml.txt
@@ -1,7 +1,9 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:1" file="f1" line="1"/>
-  <ArrayType id="_2" min="0" max="1" type="_4"/>
+  <ArrayType id="_2" min="0" max="1" type="_4">
+    <Size>2</Size>
+  </ArrayType>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/ArrayType.cxx"/>

--- a/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
@@ -1,22 +1,27 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_9" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Field id="_4" name="data2D" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ArrayType id="_8" min="0" max="1" type="_11">
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ArrayType id="_9" min="0" max="1" type="_13">
     <Size>2</Size>
   </ArrayType>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_10" min="0" max="" type="_13">
+    <Size></Size>
+    <Size>6</Size>
+  </ArrayType>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_13" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-array.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/gccxml.any.Class-implicit-member-array.xml.txt
@@ -10,7 +10,9 @@
     <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
   <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ArrayType id="_8" min="0" max="1" type="_11"/>
+  <ArrayType id="_8" min="0" max="1" type="_11">
+    <Size>2</Size>
+  </ArrayType>
   <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>

--- a/test/expect/gccxml.any.Function-Argument-decay.xml.txt
+++ b/test/expect/gccxml.any.Function-Argument-decay.xml.txt
@@ -2,16 +2,21 @@
 <GCC_XML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_6" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_4" min="0" max="1" type="_7">
+    <Size>2</Size>
+  </ArrayType>
+  <ArrayType id="_5" min="0" max="" type="_7">
+    <Size></Size>
+  </ArrayType>
+  <PointerType id="_6" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_7" returns="_6">
-    <Argument type="_6"/>
+  <FunctionType id="_8" returns="_7">
+    <Argument type="_7"/>
   </FunctionType>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </GCC_XML>$

--- a/test/input/Class-implicit-member-array.cxx
+++ b/test/input/Class-implicit-member-array.cxx
@@ -1,4 +1,5 @@
 class start
 {
   int data[2];
+  int data2D[][6];
 };


### PR DESCRIPTION
See issue **https://github.com/CastXML/CastXML/issues/96**
Array parameters in a function are now emitted as array types, rather than pointer types. I have added a <Size> element to the <Array> element to handle single and multi-dimensional arrays. The max/min attributes in <Array> are basically redundant, but I have left them there for backward compatibility. I have updated the test suite.

I'm undecided about whether an array parameter in a function should alternatively decay to a pointer to an array, like a callback function parameter does.