### PR TITLE
Output type info for array parameters in functions

### DIFF
--- a/test/expect/castxml1.any.Function-Argument-decay.xml.txt
+++ b/test/expect/castxml1.any.Function-Argument-decay.xml.txt
@@ -2,16 +2,17 @@
 <CastXML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_6" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_4" min="0" max="1" type="_7"/>
+  <ArrayType id="_5" min="0" max="" type="_7"/>
+  <PointerType id="_6" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_7" returns="_6">
-    <Argument type="_6"/>
+  <FunctionType id="_8" returns="_7">
+    <Argument type="_7"/>
   </FunctionType>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </CastXML>$

--- a/test/expect/gccxml.any.Function-Argument-decay.xml.txt
+++ b/test/expect/gccxml.any.Function-Argument-decay.xml.txt
@@ -2,16 +2,17 @@
 <GCC_XML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_6" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_4" min="0" max="1" type="_7"/>
+  <ArrayType id="_5" min="0" max="" type="_7"/>
+  <PointerType id="_6" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_7" returns="_6">
-    <Argument type="_6"/>
+  <FunctionType id="_8" returns="_7">
+    <Argument type="_7"/>
   </FunctionType>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </GCC_XML>$


### PR DESCRIPTION
See issue **https://github.com/CastXML/CastXML/issues/96**
Array parameters in a function are now emitted as array types, rather than pointer types. 

I'll let you decide how to output multi-dimensional array sizes in the xml.

It might also be worth using isFunctionType() to output a function reference for callbacks, rather than decaying to a pointer. 
