### PR TITLE
Skip system header output

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -28,6 +28,7 @@ struct Options
     , HaveCC(false)
     , HaveStd(false)
     , HaveTarget(false)
+    , SkipSystemHeaderOutput(false)
     , CastXmlEpicFormatVersion(1)
   {
   }
@@ -37,6 +38,7 @@ struct Options
   bool HaveCC;
   bool HaveStd;
   bool HaveTarget;
+  bool SkipSystemHeaderOutput;
   unsigned int CastXmlEpicFormatVersion;
   struct Include
   {

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -50,12 +50,14 @@ protected:
   clang::CompilerInstance& CI;
   clang::ASTContext const& CTX;
   llvm::raw_ostream& OS;
+  clang::SourceManager const& Manager;
 
   ASTVisitorBase(clang::CompilerInstance& ci, clang::ASTContext const& ctx,
                  llvm::raw_ostream& os)
     : CI(ci)
     , CTX(ctx)
     , OS(os)
+    , Manager(ctx.getSourceManager())
   {
   }
 
@@ -904,6 +906,16 @@ void ASTVisitor::AddDeclContextMembers(clang::DeclContext const* dc,
     // Skip declarations that are not really members of this context.
     if (d->getDeclContext() != dc) {
       continue;
+    }
+
+    //Skip system header files
+    if (Opts.SkipSystemHeaderOutput)
+    {
+      clang::SourceLocation location = d->getLocation();
+      if (this->Manager.isInExternCSystemHeader(location) || this->Manager.isInSystemHeader(location))
+      {
+        continue;
+      }
     }
 
     // Skip declarations that we use internally as builtins.

--- a/src/castxml.cxx
+++ b/src/castxml.cxx
@@ -276,7 +276,23 @@ int main(int argc_in, const char** argv_in)
         /* clang-format on */
         return 1;
       }
-    } else if (strcmp(argv[i], "-help") == 0 ||
+    } 
+    else if (strcmp(argv[i], "--castxml-skip-system-headers") == 0) {
+      if (!opts.SkipSystemHeaderOutput) {
+        opts.SkipSystemHeaderOutput = true;
+      }
+      else {
+        /* clang-format off */
+        std::cerr <<
+          "error: '--castxml-skip-system-headers' may be given at most once!\n"
+          "\n" <<
+          usage
+          ;
+        /* clang-format on */
+        return 1;
+      }
+    }
+    else if (strcmp(argv[i], "-help") == 0 ||
                strcmp(argv[i], "--help") == 0) {
       /* clang-format off */
       std::cout <<


### PR DESCRIPTION
See issue https://github.com/CastXML/CastXML/issues/93
This fix greatly reduces the verbosity of the XML output, by eliminating all the C++ standard types contained in the system headers. The filter is enabled by passing a runtime parameter to CastXML.