### PR TITLE
Filter the output of declarations according to their visibility

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -18,6 +18,9 @@
 
 #include <string>
 #include <vector>
+#include <set>
+
+#include "clang/Basic/Specifiers.h"
 
 struct Options
 {
@@ -53,6 +56,7 @@ struct Options
   std::string Predefines;
   std::string Triple;
   std::vector<std::string> StartNames;
+  std::set<clang::AccessSpecifier> ExcludedVisibility;
 };
 
 #endif // CASTXML_OPTIONS_H

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -906,6 +906,14 @@ void ASTVisitor::AddDeclContextMembers(clang::DeclContext const* dc,
       continue;
     }
 
+    clang::AccessSpecifier visibility = d->getAccess();
+    if (visibility != clang::AS_none) {
+      if (Opts.ExcludedVisibility.find(visibility) != Opts.ExcludedVisibility.end()) {
+        //the visibility of this declaration is in the exclusion set
+        continue;
+      }
+    }
+
     // Skip declarations that we use internally as builtins.
     if (isTranslationUnit) {
       if (clang::NamedDecl const* nd = clang::dyn_cast<clang::NamedDecl>(d)) {

--- a/src/castxml.cxx
+++ b/src/castxml.cxx
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <system_error>
 #include <vector>
+#include <map>
 
 #if LLVM_VERSION_MAJOR > 3 ||                                                 \
   LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7
@@ -122,6 +123,11 @@ int main(int argc_in, const char** argv_in)
     "    name(s).  Multiple names may be specified as a comma-separated\n"
     "    list or by repeating the option.\n"
     "\n"
+    "  --castxml-exclude-by-visibility <specifier>[,<specifier>]...\n"
+    "    Filter out declarations with the given visibility (private||protected||public)\n"
+    "    specifier(s). Multiple specifiers may be provided as a comma-separated\n"
+    "    list or by repeating the option.\n"
+    "\n"
     "  -help, --help\n"
     "    Print castxml and internal Clang compiler usage information\n"
     "\n"
@@ -138,6 +144,13 @@ int main(int argc_in, const char** argv_in)
   llvm::SmallVector<const char*, 16> clang_args;
   llvm::SmallVector<const char*, 16> cc_args;
   const char* cc_id = 0;
+
+  typedef std::map<std::string, clang::AccessSpecifier> VisibilityMapType;
+  VisibilityMapType TextToVisibility = {
+    { "private",  clang::AccessSpecifier::AS_private },
+    { "protected", clang::AccessSpecifier::AS_protected },
+    { "public" , clang::AccessSpecifier::AS_public }
+  };
 
   for (size_t i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--castxml-gccxml") == 0) {
@@ -276,8 +289,32 @@ int main(int argc_in, const char** argv_in)
         /* clang-format on */
         return 1;
       }
-    } else if (strcmp(argv[i], "-help") == 0 ||
-               strcmp(argv[i], "--help") == 0) {
+    }
+    else if (strcmp(argv[i], "--castxml-exclude-by-visibility") == 0) {
+      if ((i + 1) < argc) {
+        std::string item;
+        std::stringstream stream(argv[++i]);
+        while (std::getline(stream, item, ',')) {
+          VisibilityMapType::iterator iterator = TextToVisibility.find(item);
+          if (iterator != TextToVisibility.end()) {
+            opts.ExcludedVisibility.insert(iterator->second);
+          }
+        }
+      }
+      else {
+        /* clang-format off */
+        std::cerr <<
+          "error: argument to '--castxml-exclude-by-visibility' is missing "
+          "(expected 1 value)\n"
+          "\n" <<
+          usage
+          ;
+        /* clang-format on */
+        return 1;
+      }
+    }
+    else if (strcmp(argv[i], "-help") == 0 ||
+      strcmp(argv[i], "--help") == 0) {
       /* clang-format off */
       std::cout <<
         usage <<


### PR DESCRIPTION
This patch greatly reduces the XML output, as it allows the use of access specifiers to limit the number of  declarations exported. 

When wrapping code into another language, one is typically only interested in the public methods of a class or file. The command line switch `--castxml-exclude-by-visibility private,protected` filters out the extraneous text.