### PR TITLE
Output: Add original types to decayed function parameters

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -1671,6 +1671,13 @@ void ASTVisitor::OutputFunctionArgument(clang::ParmVarDecl const* a,
     this->PrintNameAttribute(name);
   }
   this->PrintTypeAttribute(a->getType(), complete);
+
+  if (a->getOriginalType() != a->getType()) {
+    this->OS << " original_type=\"";
+    this->PrintTypeIdRef(a->getOriginalType(), complete);
+    this->OS << "\"";
+  }
+
   this->PrintLocationAttribute(a);
   if (def) {
     this->OS << " default=\"";
@@ -2192,14 +2199,14 @@ void ASTVisitor::OutputStartXMLTags()
     // Start dump with castxml-compatible format.
     /* clang-format off */
     this->OS <<
-      "<CastXML format=\"" << Opts.CastXmlEpicFormatVersion << ".1.4\">\n"
+      "<CastXML format=\"" << Opts.CastXmlEpicFormatVersion << ".1.5\">\n"
       ;
     /* clang-format on */
   } else if (this->Opts.GccXml) {
     // Start dump with gccxml-compatible format (legacy).
     /* clang-format off */
     this->OS <<
-      "<GCC_XML version=\"0.9.0\" cvs_revision=\"1.144\">\n"
+      "<GCC_XML version=\"0.9.0\" cvs_revision=\"1.145\">\n"
       ;
     /* clang-format on */
   }

--- a/test/expect/castxml1.any.Function-Argument-decay.xml.txt
+++ b/test/expect/castxml1.any.Function-Argument-decay.xml.txt
@@ -1,20 +1,23 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_5" location="f1:1" file="f1" line="1"/>
-    <Argument type="_5" location="f1:1" file="f1" line="1"/>
-    <Argument type="_6" location="f1:1" file="f1" line="1"/>
+    <Argument type="_4" original_type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" original_type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" original_type="_8" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" original_type="_10" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_6" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <Namespace id="_3" name="::"/>
-  <ArrayType id="_7" min="0" max="2" type="_8"/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_9" returns="_8">
-    <Argument type="_8"/>
+  <PointerType id="_4" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_5" min="0" max="3" type="_11"/>
+  <PointerType id="_6" type="_12" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_7" min="0" max="1" type="_12"/>
+  <ArrayType id="_8" min="0" max="" type="_12"/>
+  <PointerType id="_9" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <FunctionType id="_10" returns="_12">
+    <Argument type="_12"/>
   </FunctionType>
+  <ArrayType id="_11" min="0" max="2" type="_12"/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Function-Argument-decay.xml.txt
+++ b/test/expect/castxml1.any.Function-Argument-decay.xml.txt
@@ -2,16 +2,19 @@
 <CastXML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_6" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_4" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_5" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_6" type="_9" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_7" returns="_6">
-    <Argument type="_6"/>
+  <ArrayType id="_7" min="0" max="2" type="_8"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FunctionType id="_9" returns="_8">
+    <Argument type="_8"/>
   </FunctionType>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </CastXML>$

--- a/test/expect/gccxml.any.Function-Argument-decay.xml.txt
+++ b/test/expect/gccxml.any.Function-Argument-decay.xml.txt
@@ -2,16 +2,19 @@
 <GCC_XML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
     <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
     <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_6" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_4" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_5" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_6" type="_9" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_7" returns="_6">
-    <Argument type="_6"/>
+  <ArrayType id="_7" min="0" max="2" type="_8"/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FunctionType id="_9" returns="_8">
+    <Argument type="_8"/>
   </FunctionType>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </GCC_XML>$

--- a/test/expect/gccxml.any.Function-Argument-decay.xml.txt
+++ b/test/expect/gccxml.any.Function-Argument-decay.xml.txt
@@ -1,20 +1,23 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
   <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
-    <Argument type="_4" location="f1:1" file="f1" line="1"/>
-    <Argument type="_5" location="f1:1" file="f1" line="1"/>
-    <Argument type="_5" location="f1:1" file="f1" line="1"/>
-    <Argument type="_6" location="f1:1" file="f1" line="1"/>
+    <Argument type="_4" original_type="_5" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" original_type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_6" original_type="_8" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" original_type="_10" location="f1:1" file="f1" line="1"/>
   </Function>
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_4" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_5" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_6" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <Namespace id="_3" name="::"/>
-  <ArrayType id="_7" min="0" max="2" type="_8"/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FunctionType id="_9" returns="_8">
-    <Argument type="_8"/>
+  <PointerType id="_4" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_5" min="0" max="3" type="_11"/>
+  <PointerType id="_6" type="_12" size="[0-9]+" align="[0-9]+"/>
+  <ArrayType id="_7" min="0" max="1" type="_12"/>
+  <ArrayType id="_8" min="0" max="" type="_12"/>
+  <PointerType id="_9" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <FunctionType id="_10" returns="_12">
+    <Argument type="_12"/>
   </FunctionType>
+  <ArrayType id="_11" min="0" max="2" type="_12"/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Function-Argument-decay.cxx"/>
 </GCC_XML>$

--- a/test/input/Function-Argument-decay.cxx
+++ b/test/input/Function-Argument-decay.cxx
@@ -1,1 +1,1 @@
-void start(int[2], int[], int(int));
+void start(int[4][3], int[2], int[], int(int));


### PR DESCRIPTION
Some types decay when used in function parameters (e.g. arrays become pointers).  When this occurs, add an `original_type` attribute to reference the original type without decay.

Also add a test case covering multi-dimensional arrays in function arguments.  Only the top-level decays.

Issue: #96 