### PR TITLE
Port to LLVM/Clang SVN r338041 (trunk)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ To build CastXML from source, first obtain the prerequisites:
   This version of CastXML has been tested with LLVM/Clang
 
   - SVN revision ``319768`` (trunk)
+  - Release ``6.0``
   - Release ``5.0``
   - Release ``4.0``
   - Release ``3.9``

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
-  - SVN revision ``319768`` (trunk)
+  - SVN revision ``338041`` (trunk)
   - Release ``6.0``
   - Release ``5.0``
   - Release ``4.0``

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -147,12 +147,20 @@ bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,
   redirects[2] = &errFile;
 #endif
 
+#if LLVM_VERSION_MAJOR >= 7
+  llvm::SmallVector<llvm::StringRef, 64> cmd(argv, argv + argc);
+  llvm::ArrayRef<llvm::StringRef> args = cmd;
+  llvm::Optional<llvm::ArrayRef<llvm::StringRef>> env = llvm::None;
+#else
   std::vector<const char*> cmd(argv, argv + argc);
   cmd.push_back(0);
+  const char** args = &*cmd.begin();
+  const char** env = nullptr;
+#endif
 
   // Actually run the command.
-  ret = llvm::sys::ExecuteAndWait(prog, &*cmd.begin(), nullptr, redirects, 0,
-                                  0, &msg, nullptr);
+  ret =
+    llvm::sys::ExecuteAndWait(prog, args, env, redirects, 0, 0, &msg, nullptr);
 
   // Load the output from the temporary files.
   {

--- a/src/castxml.cxx
+++ b/src/castxml.cxx
@@ -55,11 +55,6 @@ int main(int argc_in, const char** argv_in)
 {
   suppressInteractiveErrors();
 
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
-
   llvm::SmallVector<const char*, 64> argv;
   llvm::SpecificBumpPtrAllocator<char> argAlloc;
   if (std::error_code e = llvm::sys::Process::GetArgumentVector(
@@ -70,6 +65,11 @@ int main(int argc_in, const char** argv_in)
     llvm::errs() << "error: no argv[0]?!\n";
     return 1;
   }
+
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllAsmParsers();
 
 #if LLVM_VERSION_MAJOR > 3 ||                                                 \
   LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 8

--- a/src/castxml.cxx
+++ b/src/castxml.cxx
@@ -28,6 +28,10 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 
+#if LLVM_VERSION_MAJOR >= 7
+#include "llvm/Support/InitLLVM.h"
+#endif
+
 #include <iostream>
 #include <set>
 #include <sstream>
@@ -55,13 +59,20 @@ int main(int argc_in, const char** argv_in)
 {
   suppressInteractiveErrors();
 
+#if LLVM_VERSION_MAJOR >= 7
+  llvm::InitLLVM initLLVM(argc_in, argv_in);
+  llvm::SmallVector<const char*, 64> argv(argv_in, argv_in + argc_in);
+#else
   llvm::SmallVector<const char*, 64> argv;
   llvm::SpecificBumpPtrAllocator<char> argAlloc;
   if (std::error_code e = llvm::sys::Process::GetArgumentVector(
         argv, llvm::ArrayRef<const char*>(argv_in, argc_in), argAlloc)) {
     llvm::errs() << "error: could not get arguments: " << e.message() << "\n";
     return 1;
-  } else if (argv.empty()) {
+  }
+#endif
+
+  if (argv.empty()) {
     llvm::errs() << "error: no argv[0]?!\n";
     return 1;
   }


### PR DESCRIPTION
LLVM/Clang commit r334518 (Refactor ExecuteAndWait to take StringRefs,
2018-06-12) changed the signature of `ExecuteAndWait`.  Update our call.

LLVM/Clang commit r330216 (Rename sys::Process::GetArgumentVector ->
sys::windows::GetCommandLineArguments, 2018-04-17) removed the
`GetArgumentVector` API we were using.  Instead use `InitLLVM` to get
proper command-line arguments as was done for Clang by LLVM/Clang
commit r330067 (Use InitLLVM in clang as well, 2018-04-13).

Also document existing support for LLVM/Clang 6.0.
