### PR TITLE
Detect: Add more VS predefined macros

### DIFF
--- a/share/castxml/detect_vs.c
+++ b/share/castxml/detect_vs.c
@@ -20,6 +20,9 @@
 #define TO_DEFINE(x) "#define " #x " " TO_STRING(x)
 
 #pragma message("")
+#ifdef __ATOM__
+# pragma message(TO_DEFINE(__ATOM__))
+#endif
 #ifdef __AVX__
 # pragma message(TO_DEFINE(__AVX__))
 #endif
@@ -31,6 +34,9 @@
 #endif
 #ifdef _CHAR_UNSIGNED
 # pragma message(TO_DEFINE(_CHAR_UNSIGNED))
+#endif
+#ifdef _CONTROL_FLOW_GUARD
+# pragma message(TO_DEFINE(_CONTROL_FLOW_GUARD))
 #endif
 #ifdef _CPPRTTI
 # pragma message(TO_DEFINE(_CPPRTTI))
@@ -46,6 +52,12 @@
 #endif
 #ifdef _INTEGRAL_MAX_BITS
 # pragma message(TO_DEFINE(_INTEGRAL_MAX_BITS))
+#endif
+#ifdef _ISO_VOLATILE
+# pragma message(TO_DEFINE(_ISO_VOLATILE))
+#endif
+#ifdef _KERNEL_MODE
+# pragma message(TO_DEFINE(_KERNEL_MODE))
 #endif
 #ifdef _MANAGED
 # pragma message(TO_DEFINE(_MANAGED))
@@ -77,6 +89,12 @@
 #ifdef _M_ARM
 # pragma message(TO_DEFINE(_M_ARM))
 #endif
+#ifdef _M_ARM64
+# pragma message(TO_DEFINE(_M_ARM64))
+#endif
+#ifdef _M_ARM_ARMV7VE
+# pragma message(TO_DEFINE(_M_ARM_ARMV7VE))
+#endif
 #ifdef _M_ARM_FP
 # pragma message(TO_DEFINE(_M_ARM_FP))
 #endif
@@ -88,6 +106,18 @@
 #endif
 #ifdef _M_CEE_SAFE
 # pragma message(TO_DEFINE(_M_CEE_SAFE))
+#endif
+#ifdef _M_FP_EXCEPT
+# pragma message(TO_DEFINE(_M_FP_EXCEPT))
+#endif
+#ifdef _M_FP_FAST
+# pragma message(TO_DEFINE(_M_FP_FAST))
+#endif
+#ifdef _M_FP_PRECISE
+# pragma message(TO_DEFINE(_M_FP_PRECISE))
+#endif
+#ifdef _M_FP_STRICT
+# pragma message(TO_DEFINE(_M_FP_STRICT))
 #endif
 #ifdef _M_IA64
 # pragma message(TO_DEFINE(_M_IA64))
@@ -116,6 +146,9 @@
 #ifdef _OPENMP
 # pragma message(TO_DEFINE(_OPENMP))
 #endif
+#ifdef _PREFAST_
+# pragma message(TO_DEFINE(_PREFAST_))
+#endif
 #ifdef _VC_NODEFAULTLIB
 # pragma message(TO_DEFINE(_VC_NODEFAULTLIB))
 #endif
@@ -128,6 +161,9 @@
 #ifdef _WIN64
 # pragma message(TO_DEFINE(_WIN64))
 #endif
+#ifdef _WINRT_DLL
+# pragma message(TO_DEFINE(_WINRT_DLL))
+#endif
 #ifdef _Wp64
 # pragma message(TO_DEFINE(_Wp64))
 #endif
@@ -136,4 +172,10 @@
 #endif
 #ifdef __MSVC_RUNTIME_CHECKS
 # pragma message(TO_DEFINE(__MSVC_RUNTIME_CHECKS))
+#endif
+#ifdef __STDC__
+# pragma message(TO_DEFINE(__STDC__))
+#endif
+#ifdef __STDC_HOSTED__
+# pragma message(TO_DEFINE(__STDC_HOSTED__))
 #endif

--- a/share/castxml/detect_vs.cpp
+++ b/share/castxml/detect_vs.cpp
@@ -176,6 +176,12 @@
 #ifdef __MSVC_RUNTIME_CHECKS
 # pragma message(TO_DEFINE(__MSVC_RUNTIME_CHECKS))
 #endif
+#ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
+# pragma message(TO_DEFINE(__STDCPP_DEFAULT_NEW_ALIGNMENT__))
+#endif
+#ifdef __STDCPP_STRICT_POINTER_SAFETY__
+# pragma message(TO_DEFINE(__STDCPP_STRICT_POINTER_SAFETY__))
+#endif
 #ifdef __STDCPP_THREADS__
 # pragma message(TO_DEFINE(__STDCPP_THREADS__))
 #endif

--- a/share/castxml/detect_vs.cpp
+++ b/share/castxml/detect_vs.cpp
@@ -20,6 +20,9 @@
 #define TO_DEFINE(x) "#define " #x " " TO_STRING(x)
 
 #pragma message("")
+#ifdef __ATOM__
+# pragma message(TO_DEFINE(__ATOM__))
+#endif
 #ifdef __AVX__
 # pragma message(TO_DEFINE(__AVX__))
 #endif
@@ -31,6 +34,9 @@
 #endif
 #ifdef _CHAR_UNSIGNED
 # pragma message(TO_DEFINE(_CHAR_UNSIGNED))
+#endif
+#ifdef _CONTROL_FLOW_GUARD
+# pragma message(TO_DEFINE(_CONTROL_FLOW_GUARD))
 #endif
 #ifdef _CPPRTTI
 # pragma message(TO_DEFINE(_CPPRTTI))
@@ -46,6 +52,12 @@
 #endif
 #ifdef _INTEGRAL_MAX_BITS
 # pragma message(TO_DEFINE(_INTEGRAL_MAX_BITS))
+#endif
+#ifdef _ISO_VOLATILE
+# pragma message(TO_DEFINE(_ISO_VOLATILE))
+#endif
+#ifdef _KERNEL_MODE
+# pragma message(TO_DEFINE(_KERNEL_MODE))
 #endif
 #ifdef _MANAGED
 # pragma message(TO_DEFINE(_MANAGED))
@@ -80,6 +92,12 @@
 #ifdef _M_ARM
 # pragma message(TO_DEFINE(_M_ARM))
 #endif
+#ifdef _M_ARM64
+# pragma message(TO_DEFINE(_M_ARM64))
+#endif
+#ifdef _M_ARM_ARMV7VE
+# pragma message(TO_DEFINE(_M_ARM_ARMV7VE))
+#endif
 #ifdef _M_ARM_FP
 # pragma message(TO_DEFINE(_M_ARM_FP))
 #endif
@@ -91,6 +109,18 @@
 #endif
 #ifdef _M_CEE_SAFE
 # pragma message(TO_DEFINE(_M_CEE_SAFE))
+#endif
+#ifdef _M_FP_EXCEPT
+# pragma message(TO_DEFINE(_M_FP_EXCEPT))
+#endif
+#ifdef _M_FP_FAST
+# pragma message(TO_DEFINE(_M_FP_FAST))
+#endif
+#ifdef _M_FP_PRECISE
+# pragma message(TO_DEFINE(_M_FP_PRECISE))
+#endif
+#ifdef _M_FP_STRICT
+# pragma message(TO_DEFINE(_M_FP_STRICT))
 #endif
 #ifdef _M_IA64
 # pragma message(TO_DEFINE(_M_IA64))
@@ -119,6 +149,9 @@
 #ifdef _OPENMP
 # pragma message(TO_DEFINE(_OPENMP))
 #endif
+#ifdef _PREFAST_
+# pragma message(TO_DEFINE(_PREFAST_))
+#endif
 #ifdef _VC_NODEFAULTLIB
 # pragma message(TO_DEFINE(_VC_NODEFAULTLIB))
 #endif
@@ -131,6 +164,9 @@
 #ifdef _WIN64
 # pragma message(TO_DEFINE(_WIN64))
 #endif
+#ifdef _WINRT_DLL
+# pragma message(TO_DEFINE(_WINRT_DLL))
+#endif
 #ifdef _Wp64
 # pragma message(TO_DEFINE(_Wp64))
 #endif
@@ -139,6 +175,9 @@
 #endif
 #ifdef __MSVC_RUNTIME_CHECKS
 # pragma message(TO_DEFINE(__MSVC_RUNTIME_CHECKS))
+#endif
+#ifdef __STDCPP_THREADS__
+# pragma message(TO_DEFINE(__STDCPP_THREADS__))
 #endif
 #ifdef __cplusplus
 # pragma message(TO_DEFINE(__cplusplus))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -394,6 +394,7 @@ castxml_test_cmd(cc-msvc-std-c++98 --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> 
 castxml_test_cmd(cc-msvc-std-c++11 --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1600 ")" ${empty_cxx} "-###")
 castxml_test_cmd(cc-msvc-std-c++14 --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1900 ")" ${empty_cxx} "-###")
 castxml_test_cmd(cc-msvc-std-c++17 --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1900 -msvc_lang=201703L ")" ${empty_cxx} "-###")
+castxml_test_cmd(cc-msvc-std-c++17-E --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1900 -msvc_lang=201703L -stdcpp_default_new_alignment=16ll ")" ${empty_cxx} -E -dM)
 castxml_test_cmd(cc-msvc-std-explicit --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1500 ")" -std=gnu++14 ${empty_cxx} "-###")
 castxml_test_cmd(cc-msvc-builtin-1800-E --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1800 ")" ${empty_cxx} -E -dM)
 castxml_test_cmd(cc-msvc-builtin-1900-E --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1900 ")" ${empty_cxx} -E -dM)

--- a/test/cc-msvc.c
+++ b/test/cc-msvc.c
@@ -6,14 +6,17 @@ int main(int argc, const char* argv[])
   int cpp = 0;
   const char* msc_ver = "1600";
   const char* msvc_lang = 0;
+  const char* stdcpp_default_new_alignment = 0;
   int i;
   for (i = 1; i < argc; ++i) {
     if (strncmp(argv[i], "--cc-define=", 12) == 0) {
       fprintf(stdout, "\n#define %s 1", argv[i]+12);
     } else if (strncmp(argv[i], "-msc=", 5) == 0) {
       msc_ver = argv[i]+5;
-    } else if (strncmp(argv[i], "-msvc_lang=", 8) == 0) {
+    } else if (strncmp(argv[i], "-msvc_lang=", 11) == 0) {
       msvc_lang = argv[i]+11;
+    } else if (strncmp(argv[i], "-stdcpp_default_new_alignment=", 30) == 0) {
+      stdcpp_default_new_alignment = argv[i]+30;
     } else if (strstr(argv[i], ".cpp")) {
       cpp = 1;
     }
@@ -33,6 +36,11 @@ int main(int argc, const char* argv[])
     fprintf(stdout,
       "#define _MSVC_LANG %s\n", msvc_lang
       );
+  }
+  if(stdcpp_default_new_alignment) {
+    fprintf(stdout,
+      "#define __STDCPP_DEFAULT_NEW_ALIGNMENT__ %s\n",
+      stdcpp_default_new_alignment);
   }
   fprintf(stdout,
     "#define __has_include(x) x\n"

--- a/test/expect/cmd.cc-msvc-std-c++17-E.stdout.txt
+++ b/test/expect/cmd.cc-msvc-std-c++17-E.stdout.txt
@@ -1,0 +1,11 @@
+^#define _MSC_VER 1900
+#define _MSVC_LANG 201703L
+#define _WIN32 1
+#define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16ll
+#define __castxml__ [0-9]+
+#define __castxml_clang_major__ [0-9]+
+#define __castxml_clang_minor__ [0-9]+
+#define __castxml_clang_patchlevel__ [0-9]+
+#define __cplusplus 199711L
+#define __is_assignable\(_To,_Fr\) \(sizeof\(__castxml__is_assignable_check<_To,_Fr>\(0\)\) == sizeof\(char\(&\)\[1\]\)\)(
+#define __make_integer_seq __castxml__make_integer_seq)?$


### PR DESCRIPTION
Use the table at [1] to add a few missing VS 2017 predefined macros to our detection table.  Also add the `__STDCPP_DEFAULT_NEW_ALIGNMENT__` predefined VS macro.  This macro is missing from the main MSVC predefined macro list but is documented by [2] and [3].  Also add `__STDCPP_STRICT_POINTER_SAFETY__` as documented by [3] in case MSVC ever starts defining it.

[1] https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
[2] https://docs.microsoft.com/en-us/cpp/build/reference/zc-alignednew
[3] https://en.cppreference.com/w/cpp/preprocessor/replace

Fixes: #125
