### PR TITLE
cmake: drop explicit link to version.lib on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,9 +52,6 @@ set(llvm_libs
   support
   ${LLVM_TARGETS_TO_BUILD}
   )
-if(WIN32)
-  list(APPEND llvm_libs version.lib)
-endif()
 
 add_executable(castxml
   castxml.cxx


### PR DESCRIPTION
Since #132 our `llvm_libs` variable is a list of LLVM components rather than a list of raw library names.  The `version.lib` library is not a LLVM component.  Fortunately we can simply drop it because LLVM now computes the proper list of libraries for its components.

Fixes: #133  
