### PR TITLE
Convert from old python syntax to fix warning from new sphinx version

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -52,7 +52,7 @@ for fpath in castxml_manuals:
                               name, desc, [], int(sec)))
         else:
             sys.stderr.write("ERROR: No castxml-manual-description in '%s'\n" % fpath)
-    except Exception, e:
+    except Exception as e:
         sys.stderr.write("ERROR: %s\n" % str(e))
 man_show_urls = False
 


### PR DESCRIPTION
The warning is:

WARNING: Support for evaluating Python 2 syntax is deprecated and will be removed in Sphinx 4.0. Convert /builddir/build/BUILD/CastXML-9c91919574d84eefabe3ea656f08568c280da89e/doc/conf.py to Python 3 syntax.
