### PR TITLE
Version: Update version scheme to distinguish release and dev versions

### DIFF
--- a/doc/manual/castxml.1.rst
+++ b/doc/manual/castxml.1.rst
@@ -79,6 +79,21 @@ Remaining options are given to the internal Clang compiler.
 ``--version``
   Print ``castxml`` and internal Clang compiler version information.
 
+  Release versions of CastXML use the format::
+
+    <major>.<minor>.<patch>[-rc<n>][-<id>]
+
+  where the ``<patch>`` component is less than ``20000000``, ``<n>``
+  is an optional release candidate number, and ``<id>`` may contain
+  arbitrary text (in case of development between patch versions).
+
+  Development versions of CastXML use the format::
+
+    <major>.<minor>.<date>[-<id>]
+
+  where the ``<date>`` component is of format ``CCYYMMDD`` and ``<id>``
+  may contain arbitrary text.  This represents development as of a
+  particular date following the ``<major>.<minor>`` feature release.
 
 Output Format Versions
 ======================

--- a/doc/manual/castxml.1.rst
+++ b/doc/manual/castxml.1.rst
@@ -125,9 +125,23 @@ The ``--castxml-cc-<id>`` option switches the predefined macros
 to match those detected from the given compiler command.  In either
 case, CastXML always adds the following predefined macros:
 
+``__castxml_major__``
+  Defined to the CastXML major version number in decimal.
+
+``__castxml_minor__``
+  Defined to the CastXML minor version number in decimal.
+
+``__castxml_patch__``
+  Defined to the CastXML patch version number in decimal.
+
+``__castxml_check(major,minor,patch)``
+  Defined to a constant expression encoding the three version components for
+  comparison with ``__castxml__``.  The actual encoding is unspecified.
+
 ``__castxml__``
-  Defined to an integer encoding the CastXML version number as
-  ``printf("%d%03d%03d",major,minor,patch)``.
+  Defined to a constant expression encoding the CastXML version components::
+
+    __castxml_check(__castxml_major__,__castxml_minor__,__castxml_patch__)
 
 ``__castxml_clang_major__``
   Defined to the value of  ``__clang_major__`` from the internal Clang.

--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -211,10 +211,28 @@ protected:
 
     std::string builtins;
 
-    // Add a builtin to identify CastXML itself.
-    char castxml_version[64];
-    sprintf(castxml_version, "#define __castxml__ %u\n", getVersionValue());
-    builtins += castxml_version;
+    // Add builtins to identify CastXML itself.
+    {
+      char castxml_version[64];
+      sprintf(castxml_version, "#define __castxml_major__ %u\n",
+              getVersionMajor());
+      builtins += castxml_version;
+      sprintf(castxml_version, "#define __castxml_minor__ %u\n",
+              getVersionMinor());
+      builtins += castxml_version;
+      sprintf(castxml_version, "#define __castxml_patch__ %u\n",
+              getVersionPatch());
+      builtins += castxml_version;
+    }
+    // Encode the version number components to allow a date as the patch
+    // level and up to 1000 minor releases for each major release.
+    // These values can exceed a 32-bit unsigned integer, but we know
+    // that they will only be evaluated by our builtin clang.
+    builtins += "#define __castxml_check(major,minor,patch) "
+                "(10000000000*major + 100000000*minor + patch)\n";
+    builtins += "#define __castxml__ "
+                "__castxml_check(__castxml_major__,__castxml_minor__,"
+                "__castxml_patch__)\n";
 
     // Add builtins to identify the internal Clang compiler.
     builtins +=

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -102,10 +102,19 @@ std::string getVersionString()
   return CASTXML_VERSION_STRING;
 }
 
-unsigned int getVersionValue()
+unsigned int getVersionMajor()
 {
-  return (CASTXML_VERSION_MAJOR * 1000000 + CASTXML_VERSION_MINOR * 1000 +
-          CASTXML_VERSION_PATCH * 1);
+  return CASTXML_VERSION_MAJOR;
+}
+
+unsigned int getVersionMinor()
+{
+  return CASTXML_VERSION_MINOR;
+}
+
+unsigned int getVersionPatch()
+{
+  return CASTXML_VERSION_PATCH;
 }
 
 bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -32,8 +32,14 @@ std::string getClangResourceDir();
 /// getVersionString - Get the CastXML version string
 std::string getVersionString();
 
-/// getVersionValue - Get CastXML version encoded as %d%03d%03d
-unsigned int getVersionValue();
+/// getVersionMajor - Get CastXML major version.
+unsigned int getVersionMajor();
+
+/// getVersionMinor - Get CastXML minor version.
+unsigned int getVersionMinor();
+
+/// getVersionPatch - Get CastXML patch version.
+unsigned int getVersionPatch();
 
 /// runCommand - Run a given command line and capture the output.
 bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -327,13 +327,14 @@ castxml_test_cmd(rsp-missing @${input}/does-not-exist.rsp)
 castxml_test_cmd(rsp-o-missing @${input}/o-missing.rsp)
 
 # Test predefined macros when not using --castxml-cc-<id>.
-math(EXPR __castxml__ "1000000*${CastXML_VERSION_MAJOR} + 1000*${CastXML_VERSION_MINOR} + ${CastXML_VERSION_PATCH}")
 configure_file(expect/cmd.predefined-macros.stdout.txt.in
                expect/cmd.predefined-macros.stdout.txt @ONLY)
 set(castxml_test_cmd_expect ${CMAKE_CURRENT_BINARY_DIR}/expect/cmd.predefined-macros)
 castxml_test_cmd(gccxml-predefined-macros --castxml-gccxml ${empty_cxx} -E -dM)
 castxml_test_cmd(castxml-predefined-macros --castxml-output=1 ${empty_cxx} -E -dM)
 unset(castxml_test_cmd_expect)
+castxml_test_cmd(castxml-predefined-c ${input}/predefined.c)
+castxml_test_cmd(castxml-predefined-cxx ${input}/predefined.cxx)
 
 # Test --castxml-cc-gnu detection.
 add_executable(cc-gnu cc-gnu.c)

--- a/test/expect/cmd.cc-gnu-c-src-c-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-src-c-E.stdout.txt
@@ -2,7 +2,13 @@
 #define __GNUC__ 1
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
-#define __castxml_clang_patchlevel__ [0-9]+$
+#define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+$

--- a/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
@@ -4,9 +4,15 @@
 #define __OPTIMIZE__ 1
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
-#define __castxml_clang_patchlevel__ [0-9]+(
+#define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+(
 #define __float128 __castxml__float128)?
 #define __i386__ 1$

--- a/test/expect/cmd.cc-gnu-src-cxx-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-src-cxx-E.stdout.txt
@@ -2,8 +2,14 @@
 #define __GNUC__ 1
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L$

--- a/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
@@ -4,10 +4,16 @@
 #define __OPTIMIZE__ 1
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L(
 #define __float128 __castxml__float128)?
 #define __i386__ 1$

--- a/test/expect/cmd.cc-msvc-builtin-1800-E.stdout.txt
+++ b/test/expect/cmd.cc-msvc-builtin-1800-E.stdout.txt
@@ -1,7 +1,13 @@
 ^#define _MSC_VER 1800
 #define _WIN32 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L$

--- a/test/expect/cmd.cc-msvc-builtin-1900-E.stdout.txt
+++ b/test/expect/cmd.cc-msvc-builtin-1900-E.stdout.txt
@@ -1,9 +1,15 @@
 ^#define _MSC_VER 1900
 #define _WIN32 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L
 #define __is_assignable\(_To,_Fr\) \(sizeof\(__castxml__is_assignable_check<_To,_Fr>\(0\)\) == sizeof\(char\(&\)\[1\]\)\)(
 #define __make_integer_seq __castxml__make_integer_seq)?$

--- a/test/expect/cmd.cc-msvc-c-src-c-E.stdout.txt
+++ b/test/expect/cmd.cc-msvc-c-src-c-E.stdout.txt
@@ -1,6 +1,12 @@
 ^#define _MSC_VER 1600
 #define _WIN32 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
-#define __castxml_clang_patchlevel__ [0-9]+$
+#define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+$

--- a/test/expect/cmd.cc-msvc-src-cxx-E.stdout.txt
+++ b/test/expect/cmd.cc-msvc-src-cxx-E.stdout.txt
@@ -1,7 +1,13 @@
 ^#define _MSC_VER 1600
 #define _WIN32 1
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L$

--- a/test/expect/cmd.cc-msvc-std-c++17-E.stdout.txt
+++ b/test/expect/cmd.cc-msvc-std-c++17-E.stdout.txt
@@ -2,10 +2,16 @@
 #define _MSVC_LANG 201703L
 #define _WIN32 1
 #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16ll
-#define __castxml__ [0-9]+
+#define __castxml__ [^
+]*
+#define __castxml_check[^
+]*
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ [0-9]+
+#define __castxml_minor__ [0-9]+
+#define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L
 #define __is_assignable\(_To,_Fr\) \(sizeof\(__castxml__is_assignable_check<_To,_Fr>\(0\)\) == sizeof\(char\(&\)\[1\]\)\)(
 #define __make_integer_seq __castxml__make_integer_seq)?$

--- a/test/expect/cmd.predefined-macros.stdout.txt.in
+++ b/test/expect/cmd.predefined-macros.stdout.txt.in
@@ -1,7 +1,11 @@
-#define __castxml__ @__castxml__@
+#define __castxml__ __castxml_check\(__castxml_major__,__castxml_minor__,__castxml_patch__\)
+#define __castxml_check\(major,minor,patch\) \(10000000000\*major \+ 100000000\*minor \+ patch\)
 #define __castxml_clang_major__ [0-9]+
 #define __castxml_clang_minor__ [0-9]+
 #define __castxml_clang_patchlevel__ [0-9]+
+#define __castxml_major__ @CastXML_VERSION_MAJOR@
+#define __castxml_minor__ @CastXML_VERSION_MINOR@
+#define __castxml_patch__ @CastXML_VERSION_PATCH@
 #define __clang__ 1
 #define __clang_major__ [0-9]+
 #define __clang_minor__ [0-9]+

--- a/test/input/predefined.c
+++ b/test/input/predefined.c
@@ -1,0 +1,1 @@
+#include "predefined.h"

--- a/test/input/predefined.cxx
+++ b/test/input/predefined.cxx
@@ -1,0 +1,1 @@
+#include "predefined.h"

--- a/test/input/predefined.h
+++ b/test/input/predefined.h
@@ -1,0 +1,30 @@
+#ifndef __castxml_major__
+#  error "__castxml_major__ not defined"
+#endif
+#ifndef __castxml_minor__
+#  error "__castxml_minor__ not defined"
+#endif
+#ifndef __castxml_patch__
+#  error "__castxml_patch__ not defined"
+#endif
+#ifndef __castxml__
+#  error "__castxml__ not defined"
+#endif
+#ifndef __castxml_check
+#  error "__castxml_check not defined"
+#endif
+#if __castxml__ < __castxml_check(0, 1, 0)
+#  error "__castxml__ < __castxml_check(0, 1, 0)"
+#endif
+#if __castxml__ < __castxml_check(0, 0, 20000000)
+#  error "__castxml__ < __castxml_check(0, 0, 20000000)"
+#endif
+#ifndef __castxml_clang_major__
+#  error "__castxml_clang_major__ not defined"
+#endif
+#ifndef __castxml_clang_minor__
+#  error "__castxml_clang_minor__ not defined"
+#endif
+#ifndef __castxml_clang_patchlevel__
+#  error "__castxml_clang_patchlevel__ not defined"
+#endif


### PR DESCRIPTION
Use the format `<major>.<minor>.<patch>[-rc<n>][-<id>]` for release
versions and `<major>.<minor>.<date>[-<id>]` for development versions.
Assume we will identify exact release versions with a `v<ver>` tag
on a commit with subject `CastXML <ver>`.  Aadd an `-<id>` suffix to
versions that are not exact release commits.
