### PR TITLE
doc: use brighter colors for html theme

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -58,5 +58,25 @@ man_show_urls = False
 
 html_show_sourcelink = True
 html_theme = 'default'
+html_theme_options = {
+    'footerbgcolor':    '#00182d',
+    'footertextcolor':  '#ffffff',
+    'sidebarbgcolor':   '#e4ece8',
+    'sidebarbtncolor':  '#00a94f',
+    'sidebartextcolor': '#333333',
+    'sidebarlinkcolor': '#00a94f',
+    'relbarbgcolor':    '#00529b',
+    'relbartextcolor':  '#ffffff',
+    'relbarlinkcolor':  '#ffffff',
+    'bgcolor':          '#ffffff',
+    'textcolor':        '#444444',
+    'headbgcolor':      '#f2f2f2',
+    'headtextcolor':    '#003564',
+    'headlinkcolor':    '#3d8ff2',
+    'linkcolor':        '#2b63a8',
+    'visitedlinkcolor': '#2b63a8',
+    'codebgcolor':      '#eeeeee',
+    'codetextcolor':    '#333333',
+}
 html_title = 'CastXML %s Documentation' % release
 html_short_title = '%s Documentation' % release


### PR DESCRIPTION
Set the Sphinx `html_theme_options` to give the generated documentation
a brighter and softer look than the default colors.