### PR TITLE
CMake: try to use latest LLVM version instead of randomly found version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,10 @@ endmacro()
 hint_llvm_from_clang()
 hint_clang_from_llvm()
 
+# If several LLVM versions provide CMake packages, try to use the latest one.
+set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+
 # Clang 3.8+ installs its own CMake package.  Try it first.
 find_package(Clang QUIET)
 


### PR DESCRIPTION
Related to CastXML/CastXML#148.

CastXML uses `find_package(Clang)` which in case there is more than one LLVM version with CMake config files available, will pick one pretty much at random.

I experimented a bit and found that adding the below lines before `find_package` causes the **latest**, and not **random** version of LLVM to be used:
```
# If several LLVM versions provide CMake packages, try to use the latest one.
set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
```

Relevant documentation is here:

* https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_SORT_ORDER.html
* https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_SORT_DIRECTION.html

I hope you find this change is useful and beneficial for the project.