### PR TITLE
Port to LLVM/Clang SVN r375505 (trunk)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
-  - SVN revision ``370248`` (trunk)
+  - SVN revision ``375505`` (trunk)
   - Release ``9.0``
   - Release ``8.0``
   - Release ``7.0``

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -189,7 +189,11 @@ protected:
   {                                                                           \
     this->OutputUnimplementedType(t, dn);                                     \
   }
-#include "clang/AST/TypeNodes.def"
+#if LLVM_VERSION_MAJOR >= 10
+#  include "clang/AST/TypeNodes.inc"
+#else
+#  include "clang/AST/TypeNodes.def"
+#endif
 
   void OutputUnimplementedType(clang::Type const* t, DumpNode const* dn)
   {
@@ -1115,7 +1119,11 @@ void ASTVisitor::OutputType(DumpType dt, DumpNode const* dn)
     this->Output##CLASS##Type(                                                \
       static_cast<clang::CLASS##Type const*>(t.getTypePtr()), dn);            \
     break;
-#include "clang/AST/TypeNodes.def"
+#if LLVM_VERSION_MAJOR >= 10
+#  include "clang/AST/TypeNodes.inc"
+#else
+#  include "clang/AST/TypeNodes.def"
+#endif
     }
   }
 }

--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -540,8 +540,12 @@ runClangCreateDiagnostics(const char* const* argBeg, const char* const* argEnd)
     new clang::DiagnosticOptions);
   llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagID(
     new clang::DiagnosticIDs());
+#if LLVM_VERSION_MAJOR >= 10
+  llvm::opt::OptTable const* opts = &clang::driver::getDriverOptTable();
+#else
   std::unique_ptr<llvm::opt::OptTable> opts(
     clang::driver::createDriverOptTable());
+#endif
   unsigned missingArgIndex, missingArgCount;
 #if LLVM_VERSION_MAJOR > 3 ||                                                 \
   LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7


### PR DESCRIPTION
Clang renamed `clang/AST/TypeNodes.{def => inc}` and replaced the
`createDriverOptTable` factory with a singleton returned by
`getDriverOptTable`.