### PR TITLE
Output: Support function call inside decltype

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -748,14 +748,10 @@ ASTVisitor::DumpId ASTVisitor::AddTypeDumpNode(DumpType dt, bool complete,
         DumpType(t->getAs<clang::DecayedType>()->getDecayedType(), c),
         complete, dq);
     case clang::Type::Decltype:
-      if (this->Opts.CastXml && t->isNullPtrType()) {
+      if (this->Opts.CastXml) {
         clang::DecltypeType const* dtt = t->getAs<clang::DecltypeType>();
-        if (dtt->getUnderlyingExpr()->getStmtClass() ==
-            clang::Stmt::CXXNullPtrLiteralExprClass) {
-          // Treat literal 'decltype(nullptr)' as a FundamentalType.
-          return this->AddTypeDumpNode(DumpType(dtt->getUnderlyingType(), c),
-                                       complete, dq);
-        }
+        return this->AddTypeDumpNode(DumpType(dtt->getUnderlyingType(), c),
+                                     complete, dq);
       }
       break;
     case clang::Type::Elaborated:

--- a/test/expect/castxml1.any.FundamentalType-nullptr.xml.txt
+++ b/test/expect/castxml1.any.FundamentalType-nullptr.xml.txt
@@ -2,9 +2,8 @@
 <CastXML[^>]*>
   <Namespace id="_1" name="start" context="_2" members="_3 _4"/>
   <Typedef id="_3" name="t_NullPtr" type="_5" context="_1" location="f1:2" file="f1" line="2"/>
-  <Typedef id="_4" name="t_ParenNullPtr" type="_6" context="_1" location="f1:3" file="f1" line="3"/>
+  <Typedef id="_4" name="t_ParenNullPtr" type="_5" context="_1" location="f1:3" file="f1" line="3"/>
   <FundamentalType id="_5" name="decltype\(nullptr\)" size="[0-9]+" align="[0-9]+"/>
-  <Unimplemented id="_6" type_class="Decltype"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/FundamentalType-nullptr.cxx"/>
 </CastXML>$


### PR DESCRIPTION
Extend the `--castxml-output=1` format to recognize function call in
decltype. Create a dump node for the function return type.