### PR TITLE
README: Document support for LLVM/Clang 10.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Release ``10.0``
   - SVN revision ``375505`` (trunk)
   - Release ``9.0``
   - Release ``8.0``


### PR DESCRIPTION
CastXML already compiles and passes all tests against this version.