### PR TITLE
Port to LLVM/Clang Git master as of 2020-02-13 (6c73246179)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,8 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Git master as of 2020-02-13 (``6c73246179``)
   - Release ``10.0``
-  - SVN revision ``375505`` (trunk)
   - Release ``9.0``
   - Release ``8.0``
   - Release ``7.0``

--- a/src/Detect.cxx
+++ b/src/Detect.cxx
@@ -186,7 +186,7 @@ static bool detectCC_MSVC(const char* const* argBeg, const char* const* argEnd,
       includes_ref.split(includes, ";", -1, false);
       for (llvm::StringRef i : includes) {
         if (!i.empty()) {
-          std::string inc = i;
+          std::string inc(i);
           std::replace(inc.begin(), inc.end(), '\\', '/');
           opts.Includes.push_back(inc);
         }

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -19,6 +19,7 @@
 #include "Utils.h"
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclFriend.h"
@@ -397,6 +398,7 @@ class ASTVisitor : public ASTVisitorBase
 
   /** Print a name="..." attribute.  */
   void PrintNameAttribute(std::string const& name);
+  void PrintNameAttribute(llvm::StringRef name);
 
   /** Print a mangled="..." attribute.  */
   void PrintMangledAttribute(clang::NamedDecl const* d);
@@ -1078,7 +1080,7 @@ void ASTVisitor::ProcessFileQueue()
     this->OS <<
       "  <File"
       " id=\"f" << this->FileNodes[f] << "\""
-      " name=\"" << encodeXML(f->getName()) << "\""
+      " name=\"" << encodeXML(std::string(f->getName())) << "\""
       "/>\n"
       ;
     /* clang-format on */
@@ -1188,6 +1190,11 @@ void ASTVisitor::PrintNameAttribute(std::string const& name)
 {
   std::string n = stringReplace(name, "__castxml__float128_s", "__float128");
   this->OS << " name=\"" << encodeXML(n) << "\"";
+}
+
+void ASTVisitor::PrintNameAttribute(llvm::StringRef name)
+{
+  this->PrintNameAttribute(std::string(name));
 }
 
 void ASTVisitor::PrintMangledAttribute(clang::NamedDecl const* d)
@@ -1714,7 +1721,7 @@ void ASTVisitor::OutputTranslationUnitDecl(clang::TranslationUnitDecl const* d,
 {
   this->OS << "  <Namespace";
   this->PrintIdAttribute(dn);
-  this->PrintNameAttribute("::");
+  this->PrintNameAttribute(std::string("::"));
   if (dn->Complete) {
     this->PrintMembersAttribute(d);
   }

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -78,7 +78,8 @@ bool findResourceDir(const char* argv0, std::ostream& error)
     llvm::sys::path::remove_filename(dir2);
     // Build tree has
     //   <build>/bin[/<config>]/castxml
-    if (!tryBuildDir(dir.str()) && !tryBuildDir(dir2.str())) {
+    if (!tryBuildDir(std::string(dir.str())) &&
+        !tryBuildDir(std::string(dir2.str()))) {
       error << "Unable to locate resources for " << exe << "\n";
       return false;
     }


### PR DESCRIPTION
The `llvm::StringRef` type now requires explicit conversion to `std::string`.  Such explicit conversions still work with older versions of LLVM/Clang too.
