### PR TITLE
test: Add case for __builtin_assume_aligned declaration in MSVC header

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -400,6 +400,7 @@ castxml_test_cmd(cc-msvc-std-explicit --castxml-cc-msvc "(" $<TARGET_FILE:cc-msv
 castxml_test_cmd(cc-msvc-builtin-1800-E --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1800 ")" ${empty_cxx} -E -dM)
 castxml_test_cmd(cc-msvc-builtin-1900-E --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1900 ")" ${empty_cxx} -E -dM)
 castxml_test_cmd(cc-msvc-builtin-1900 --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1900 ")" ${input}/make_integer_seq.cxx)
+castxml_test_cmd(cc-msvc-builtin-1923 --castxml-cc-msvc "(" $<TARGET_FILE:cc-msvc> -msc=1923 ")" ${input}/assume_aligned.cxx)
 castxml_test_cmd(cc-msvc-c-bad-cmd --castxml-cc-msvc-c "(" cc-msvc-c-bad-cmd ")" ${empty_c})
 castxml_test_cmd(cc-msvc-c-src-c-E --castxml-cc-msvc-c $<TARGET_FILE:cc-msvc> ${empty_c} -E -dM)
 castxml_test_cmd(cc-msvc-c-src-c-cmd --castxml-cc-msvc-c $<TARGET_FILE:cc-msvc> ${empty_c} "-###")

--- a/test/input/assume_aligned.cxx
+++ b/test/input/assume_aligned.cxx
@@ -1,0 +1,8 @@
+constexpr void* __cdecl __builtin_assume_aligned(const void*, size_t,
+                                                 ...) noexcept;
+
+int* check_assume_aligned(int* p)
+{
+  __builtin_assume_aligned(p, 4);
+  return p;
+}


### PR DESCRIPTION
In #162 we left out a test case.  Add one now.
