### PR TITLE
test: Fix cc-gnu predefined macros on Windows

### DIFF
--- a/test/cc-gnu.c
+++ b/test/cc-gnu.c
@@ -27,6 +27,10 @@ int main(int argc, const char* argv[])
       );
   }
   fprintf(stdout,
+#ifdef _WIN32
+    "#define _WIN32 1\n"
+    "#define __MINGW32__ 1\n"
+#endif
     "#define __GNUC__ 1\n"
     "#define __has_include(x) x\n"
     "#define __has_include_next(x) x\n"

--- a/test/expect/cmd.cc-gnu-c-src-c-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-src-c-E.stdout.txt
@@ -1,5 +1,7 @@
-^#define __GNUC_MINOR__ 1
-#define __GNUC__ 1
+^(#define _WIN32 1
+)?#define __GNUC_MINOR__ 1
+#define __GNUC__ 1(
+#define __MINGW32__ 1)?
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
 #define __castxml__ [^

--- a/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
@@ -1,5 +1,7 @@
-^#define __GNUC_MINOR__ 1
-#define __GNUC__ 1
+^(#define _WIN32 1
+)?#define __GNUC_MINOR__ 1
+#define __GNUC__ 1(
+#define __MINGW32__ 1)?
 #define __NO_MATH_INLINES 1
 #define __OPTIMIZE__ 1
 #define __builtin_va_arg_pack\(\) 0

--- a/test/expect/cmd.cc-gnu-src-cxx-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-src-cxx-E.stdout.txt
@@ -1,5 +1,7 @@
-^#define __GNUC_MINOR__ 1
-#define __GNUC__ 1
+^(#define _WIN32 1
+)?#define __GNUC_MINOR__ 1
+#define __GNUC__ 1(
+#define __MINGW32__ 1)?
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
 #define __castxml__ [^

--- a/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
@@ -1,5 +1,7 @@
-^#define __GNUC_MINOR__ 1
-#define __GNUC__ 1
+^(#define _WIN32 1
+)?#define __GNUC_MINOR__ 1
+#define __GNUC__ 1(
+#define __MINGW32__ 1)?
 #define __NO_MATH_INLINES 1
 #define __OPTIMIZE__ 1
 #define __builtin_va_arg_pack\(\) 0


### PR DESCRIPTION
For Windows targets, GNU compilers predefine `_WIN32` and `__MINGW32__`.
CastXML uses those to set the target triple correctly when using
`--castxml-cc-gnu`.  Teach our fake GNU compiler in the test suite to
define these too.  Otherwise CastXML does not add `gnu` to the target
triple.  This causes the Windows-hosted Clang to choose `msvc` in the
default triple and enable MS compatibility, which is incorrect.