### PR TITLE
Port to LLVM/Clang Git master as of 2020-07-13

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
-  - Git master as of 2020-02-13 (``6c73246179``)
+  - Git master as of 2020-07-13 (``3d0b76022d``)
   - Release ``10.0``
   - Release ``9.0``
   - Release ``8.0``

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -31,6 +31,8 @@
 #include "clang/AST/Mangle.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/AST/RecordLayout.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Frontend/CompilerInstance.h"

--- a/test/expect/castxml1.any.Field.xml.txt
+++ b/test/expect/castxml1.any.Field.xml.txt
@@ -4,14 +4,14 @@
   <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
   <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:4" file="f1" line="4" offset="32"/>
   <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:5" file="f1" line="5" offset="64" mutable="1"/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:7" file="f1" line="7">
+    <Argument type="_12" location="f1:7" file="f1" line="7"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:8" file="f1" line="8" mangled="[^"]+">
+    <Argument type="_12" location="f1:8" file="f1" line="8"/>
   </OperatorMethod>
-  <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9"/>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:10" file="f1" line="10"/>
   <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
   <FundamentalType id="_11" name="unsigned int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>

--- a/test/expect/gccxml.any.Field.xml.txt
+++ b/test/expect/gccxml.any.Field.xml.txt
@@ -4,14 +4,14 @@
   <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
   <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:4" file="f1" line="4" offset="32"/>
   <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:5" file="f1" line="5" offset="64" mutable="1"/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:7" file="f1" line="7">
+    <Argument type="_12" location="f1:7" file="f1" line="7"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:8" file="f1" line="8" mangled="[^"]+">
+    <Argument type="_12" location="f1:8" file="f1" line="8"/>
   </OperatorMethod>
-  <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9"/>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:10" file="f1" line="10"/>
   <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
   <FundamentalType id="_11" name="unsigned int" size="[0-9]+" align="[0-9]+"/>
   <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>

--- a/test/input/Field.cxx
+++ b/test/input/Field.cxx
@@ -3,4 +3,9 @@ class start
   int field;
   unsigned bit_field : 2;
   mutable int mutable_field;
+public:
+  start(start const&);
+  start& operator=(start const&);
+  start();
+  ~start();
 };


### PR DESCRIPTION
Explicitly include Clang headers for SourceLocation and FileManager
instead of relying on other clang headers to provide them.

Fixes: #173
