### PR TITLE
README: Document support for LLVM/Clang 11.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Release ``11.0``
   - Git master as of 2020-07-13 (``3d0b76022d``)
   - Release ``10.0``
   - Release ``9.0``


### PR DESCRIPTION
CastXML already compiles and passes all tests against this version.
