### PR TITLE
Detect: Fix GNU builtin include directory detection on aarch64

### DIFF
--- a/src/Detect.cxx
+++ b/src/Detect.cxx
@@ -112,8 +112,9 @@ static bool isBuiltinIncludeDir(std::string const& inc)
 {
   // FIXME: Intrinsics headers are platform-specific.
   // Is there a better way to detect this directory?
-  return (llvm::sys::fs::exists(inc + "/emmintrin.h")  // x86_64
-          || llvm::sys::fs::exists(inc + "/altivec.h") // ppc64
+  return (llvm::sys::fs::exists(inc + "/emmintrin.h")   // x86_64
+          || llvm::sys::fs::exists(inc + "/altivec.h")  // ppc64
+          || llvm::sys::fs::exists(inc + "/arm_neon.h") // aarch64
   );
 }
 


### PR DESCRIPTION
There is no `emmintrin.h` or `altivec.h` header for this architecture, so use `arm_neon.h` instead.

Also factor out the check for compiler builtin headers into a helper function since it is getting longer.
