### PR TITLE
Switch to regular expression for comment offset

### DIFF
--- a/test/expect/castxml1.any.Comment-Class.xml.txt
+++ b/test/expect/castxml1.any.Comment-Class.xml.txt
@@ -2,6 +2,6 @@
 <CastXML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:2" file="f1" line="2" incomplete="1" comment="c1"/>
   <Namespace id="_2" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="0" end_line="1" end_column="21" end_offset="20"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="[0-9]+" end_line="1" end_column="21" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Class.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Enumeration.xml.txt
+++ b/test/expect/castxml1.any.Comment-Enumeration.xml.txt
@@ -2,6 +2,6 @@
 <CastXML[^>]*>
   <Enumeration id="_1" name="start" context="_2" location="f1:3" file="f1" line="3" size="[0-9]+" align="[0-9]+" comment="c1"/>
   <Namespace id="_2" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="0" end_line="2" end_column="24" end_offset="40"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="[0-9]+" end_line="2" end_column="24" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Enumeration.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Field.xml.txt
+++ b/test/expect/castxml1.any.Comment-Field.xml.txt
@@ -18,8 +18,8 @@
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
-  <Comment id="c1" attached="_3" file="f1" begin_line="3" begin_column="3" begin_offset="16" end_line="3" end_column="23" end_offset="36"/>
-  <Comment id="c2" attached="_4" file="f1" begin_line="5" begin_column="3" begin_offset="52" end_line="5" end_column="24" end_offset="73"/>
-  <Comment id="c3" attached="_5" file="f1" begin_line="7" begin_column="3" begin_offset="102" end_line="7" end_column="28" end_offset="127"/>
+  <Comment id="c1" attached="_3" file="f1" begin_line="3" begin_column="3" begin_offset="[0-9]+" end_line="3" end_column="23" end_offset="[0-9]+"/>
+  <Comment id="c2" attached="_4" file="f1" begin_line="5" begin_column="3" begin_offset="[0-9]+" end_line="5" end_column="24" end_offset="[0-9]+"/>
+  <Comment id="c3" attached="_5" file="f1" begin_line="7" begin_column="3" begin_offset="[0-9]+" end_line="7" end_column="28" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Field.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Function-expansion.xml.txt
+++ b/test/expect/castxml1.any.Comment-Function-expansion.xml.txt
@@ -6,6 +6,6 @@
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="17" begin_offset="16" end_line="1" end_column="40" end_offset="39"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="17" begin_offset="[0-9]+" end_line="1" end_column="40" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Function-expansion.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Function-separated.xml.txt
+++ b/test/expect/castxml1.any.Comment-Function-separated.xml.txt
@@ -6,6 +6,6 @@
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="2" begin_column="1" begin_offset="27" end_line="2" end_column="19" end_offset="45"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="2" begin_column="1" begin_offset="[0-9]+" end_line="2" end_column="19" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Function-separated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Function.xml.txt
+++ b/test/expect/castxml1.any.Comment-Function.xml.txt
@@ -6,6 +6,6 @@
   <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="0" end_line="2" end_column="27" end_offset="47"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="[0-9]+" end_line="2" end_column="27" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Function.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Method.xml.txt
+++ b/test/expect/castxml1.any.Comment-Method.xml.txt
@@ -17,6 +17,6 @@
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
-  <Comment id="c1" attached="_3" file="f1" begin_line="3" begin_column="3" begin_offset="16" end_line="3" end_column="24" end_offset="37"/>
+  <Comment id="c1" attached="_3" file="f1" begin_line="3" begin_column="3" begin_offset="[0-9]+" end_line="3" end_column="24" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Method.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Namespace.xml.txt
+++ b/test/expect/castxml1.any.Comment-Namespace.xml.txt
@@ -2,6 +2,6 @@
 <CastXML[^>]*>
   <Namespace id="_1" name="start" context="_2" comment="c1"/>
   <Namespace id="_2" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="0" end_line="2" end_column="24" end_offset="45"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="[0-9]+" end_line="2" end_column="24" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Namespace.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-TypeAlias.xml.txt
+++ b/test/expect/castxml1.any.Comment-TypeAlias.xml.txt
@@ -4,6 +4,6 @@
   <Typedef id="_3" name="type" type="_4" context="_1" location="f1:3" file="f1" line="3" comment="c1"/>
   <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
-  <Comment id="c1" attached="_3" file="f1" begin_line="2" begin_column="1" begin_offset="18" end_line="2" end_column="26" end_offset="43"/>
+  <Comment id="c1" attached="_3" file="f1" begin_line="2" begin_column="1" begin_offset="[0-9]+" end_line="2" end_column="26" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-TypeAlias.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Typedef.xml.txt
+++ b/test/expect/castxml1.any.Comment-Typedef.xml.txt
@@ -3,6 +3,6 @@
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:2" file="f1" line="2" comment="c1"/>
   <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="0" end_line="1" end_column="23" end_offset="22"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="[0-9]+" end_line="1" end_column="23" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Typedef.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Variable.xml.txt
+++ b/test/expect/castxml1.any.Comment-Variable.xml.txt
@@ -3,6 +3,6 @@
   <Variable id="_1" name="start" type="_2" context="_3" location="f1:3" file="f1" line="3" mangled="[^"]+" comment="c1"/>
   <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
-  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="0" end_line="2" end_column="27" end_offset="47"/>
+  <Comment id="c1" attached="_1" file="f1" begin_line="1" begin_column="1" begin_offset="[0-9]+" end_line="2" end_column="27" end_offset="[0-9]+"/>
   <File id="f1" name=".*/test/input/Comment-Variable.cxx"/>
 </CastXML>$


### PR DESCRIPTION
Switch from using the hard-coded values for begin and end offset of each
comment and instead use a regular expression for numbers.