### PR TITLE
Detect: Fix MSVC preprocessor settings detection on Windows 11

### DIFF
--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -119,7 +119,7 @@ unsigned int getVersionPatch()
 }
 
 bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,
-                std::string& err, std::string& msg)
+                std::string& err, std::string& msg, std::string* maybeTmpDir)
 {
   // Find the program to run.
   llvm::ErrorOr<std::string> maybeProg = llvm::sys::findProgramByName(argv[0]);
@@ -131,8 +131,10 @@ bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,
 
   // Create a temporary directory to hold output files.
   llvm::SmallString<128> tmpDir;
-  if (std::error_code e =
-        llvm::sys::fs::createUniqueDirectory("castxml", tmpDir)) {
+  if (maybeTmpDir) {
+    tmpDir = *maybeTmpDir;
+  } else if (std::error_code e =
+               llvm::sys::fs::createUniqueDirectory("castxml", tmpDir)) {
     msg = e.message();
     return false;
   }
@@ -185,7 +187,9 @@ bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,
   // Remove temporary files and directory.
   llvm::sys::fs::remove(llvm::Twine(tmpOut));
   llvm::sys::fs::remove(llvm::Twine(tmpErr));
-  llvm::sys::fs::remove(llvm::Twine(tmpDir));
+  if (!maybeTmpDir) {
+    llvm::sys::fs::remove(llvm::Twine(tmpDir));
+  }
 
   return ret >= 0;
 }

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -137,9 +137,9 @@ bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,
     return false;
   }
   llvm::SmallString<128> tmpOut = tmpDir;
-  tmpOut.append("out");
+  tmpOut.append("/out");
   llvm::SmallString<128> tmpErr = tmpDir;
-  tmpErr.append("err");
+  tmpErr.append("/err");
 
   // Construct file redirects.
   llvm::StringRef inFile; // empty means /dev/null

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -43,7 +43,8 @@ unsigned int getVersionPatch();
 
 /// runCommand - Run a given command line and capture the output.
 bool runCommand(int argc, const char* const* argv, int& ret, std::string& out,
-                std::string& err, std::string& msg);
+                std::string& err, std::string& msg,
+                std::string* maybeTmpDir = nullptr);
 
 /// suppressInteractiveErrors - Disable Windows error dialog popups
 void suppressInteractiveErrors();

--- a/test/expect/cmd.cc-msvc-bad-cmd.stderr.txt
+++ b/test/expect/cmd.cc-msvc-bad-cmd.stderr.txt
@@ -1,3 +1,3 @@
 ^error: '--castxml-cc-msvc' compiler command failed:
 
- 'cc-msvc-bad-cmd' '-c' '-FoNUL' '.*/share/castxml/detect_vs.cpp'
+ 'cc-msvc-bad-cmd' '-c' '[^']*/share/castxml/detect_vs.cpp' '-Fo[^']*/detect_vs.obj'

--- a/test/expect/cmd.cc-msvc-c-bad-cmd.stderr.txt
+++ b/test/expect/cmd.cc-msvc-c-bad-cmd.stderr.txt
@@ -1,3 +1,3 @@
 ^error: '--castxml-cc-msvc-c' compiler command failed:
 
- 'cc-msvc-c-bad-cmd' '-c' '-FoNUL' '.*/share/castxml/detect_vs.c
+ 'cc-msvc-c-bad-cmd' '-c' '[^']*/share/castxml/detect_vs.c' '-Fo[^']*/detect_vs.obj'


### PR DESCRIPTION
MSVC has no way to compile without producing the object file.
Previously we used `-FoNUL` to redirect the object file to the
null device, which `cl` opened internally as `NUL.obj`.
Windows 11 seems to treat `NUL.obj` as a real file, and only
plain `NUL` as the null device.  Opening `NUL.obj` in the
current working directory races with other CastXML processes.

Avoid this problem by putting the object file in a temporary
directory that is unique to the current process.

Fixes: #211
