### PR TITLE
README: Document support for LLVM/Clang 14.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Release ``14.0``
   - Git ``main`` as of 2021-08-25 (``24201b6437``)
   - Release ``13.0``
   - Release ``12.0``

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Git ``main`` as of 2022-05-27 (``5cd690ad9c``)
   - Release ``14.0``
-  - Git ``main`` as of 2021-08-25 (``24201b6437``)
   - Release ``13.0``
   - Release ``12.0``
   - Release ``11.0``


### PR DESCRIPTION
CastXML already compiles and passes all tests against this version.

Also document a more recent version on the `main` branch that is known to work.