### PR TITLE
Output: Restore type references through using decls with LLVM/Clang 14+

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -833,6 +833,12 @@ ASTVisitor::DumpId ASTVisitor::AddTypeDumpNode(DumpType dt, bool complete,
       }
       return this->AddDeclDumpNodeForType(tdt->getDecl(), complete, dq);
     } break;
+#if LLVM_VERSION_MAJOR >= 14
+    case clang::Type::Using: {
+      clang::UsingType const* ut = t->getAs<clang::UsingType>();
+      return this->AddTypeDumpNode(DumpType(ut->desugar(), c), complete, dq);
+    } break;
+#endif
     default:
       break;
   }

--- a/test/expect/castxml1.any.using-declaration-ns.xml.txt
+++ b/test/expect/castxml1.any.using-declaration-ns.xml.txt
@@ -1,7 +1,8 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Namespace id="_1" name="start" context="_2" members="_3"/>
+  <Namespace id="_1" name="start" context="_2" members="_3 _4"/>
   <Class id="_3" name="A" context="_2" location="f1:1" file="f1" line="1" incomplete="1"/>
+  <Typedef id="_4" name="B" type="_3" context="_1" location="f1:4" file="f1" line="4"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/using-declaration-ns.cxx"/>
 </CastXML>$

--- a/test/expect/gccxml.any.using-declaration-ns.xml.txt
+++ b/test/expect/gccxml.any.using-declaration-ns.xml.txt
@@ -1,7 +1,8 @@
 ^<\?xml version="1.0"\?>
 <GCC_XML[^>]*>
-  <Namespace id="_1" name="start" context="_2" members="_3"/>
+  <Namespace id="_1" name="start" context="_2" members="_3 _4"/>
   <Class id="_3" name="A" context="_2" location="f1:1" file="f1" line="1" incomplete="1"/>
+  <Typedef id="_4" name="B" type="_3" context="_1" location="f1:4" file="f1" line="4"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/using-declaration-ns.cxx"/>
 </GCC_XML>$

--- a/test/input/using-declaration-ns.cxx
+++ b/test/input/using-declaration-ns.cxx
@@ -1,4 +1,5 @@
 class A;
 namespace start {
 using ::A;
+typedef A B;
 }


### PR DESCRIPTION
LLVM/Clang 14 introduced a `UsingType` indirection to represent type references through using declarations.  Report the underlying type as before.

See LLVM/Clang commit `e1600db19d63` ([AST] Add UsingType: a sugar type for types found via UsingDecl, 2021-11-19) and commit `af27466c5039` (Reland "[AST] Add UsingType: a sugar type for types found via UsingDecl", 2021-12-20).

Fixes: #220