### PR TITLE
RunClang: Fix arm64v8 rounding intrinsics when simulating GCC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -345,6 +345,7 @@ add_executable(cc-gnu cc-gnu.c)
 set_property(SOURCE cc-gnu.c APPEND PROPERTY COMPILE_DEFINITIONS
   "TEST_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 castxml_test_cmd(cc-gnu-bad-cmd --castxml-cc-gnu cc-gnu-bad-cmd ${empty_cxx})
+castxml_test_cmd(cc-gnu-intrinsics-arm64v8 --castxml-cc-gnu "(" $<TARGET_FILE:cc-gnu> -tgt-arm64v8 ")" -v ${input}/intrinsics-arm64v8.cxx)
 castxml_test_cmd(cc-gnu-src-c-E --castxml-cc-gnu $<TARGET_FILE:cc-gnu> ${empty_c} -E -dM)
 castxml_test_cmd(cc-gnu-src-cxx-E --castxml-cc-gnu $<TARGET_FILE:cc-gnu> ${empty_cxx} -E -dM)
 castxml_test_cmd(cc-gnu-src-cxx-cmd --castxml-cc-gnu $<TARGET_FILE:cc-gnu> ${empty_cxx} "-###")

--- a/test/cc-gnu.c
+++ b/test/cc-gnu.c
@@ -13,6 +13,9 @@ int main(int argc, const char* argv[])
       std_date = argv[i]+5;
     } else if (strcmp(argv[i], "-ansi") == 0) {
       fprintf(stdout, "#define __STRICT_ANSI__ 1\n");
+    } else if (strcmp(argv[i], "-tgt-arm64v8") == 0) {
+      fprintf(stdout, "#define __aarch64__ 1\n");
+      fprintf(stdout, "#define __ARM_ARCH 8\n");
     } else if (strstr(argv[i], ".cpp")) {
       cpp = 1;
     }

--- a/test/expect/cmd.cc-gnu-intrinsics-arm64v8.stderr.txt
+++ b/test/expect/cmd.cc-gnu-intrinsics-arm64v8.stderr.txt
@@ -1,0 +1,3 @@
+Target: aarch64-[^
+]+
+.

--- a/test/input/intrinsics-arm64v8.cxx
+++ b/test/input/intrinsics-arm64v8.cxx
@@ -1,0 +1,6 @@
+#if !defined(__ARM_ARCH) || __ARM_ARCH != 8
+#  error "__ARM_ARCH is incorrectly not defined to 8"
+#endif
+#ifndef __ARM_FEATURE_DIRECTED_ROUNDING
+#  error "__ARM_FEATURE_DIRECTED_ROUNDING incorrectly not defined"
+#endif


### PR DESCRIPTION
LLVM/Clang predefines `__ARM_FEATURE_DIRECTED_ROUNDING` when ever it defines `__ARM_ARCH >= 8`.  Its corresponding `arm_neon.h` intrinsics header relies on the feature macro to provide rounding intrinsics. GCC does not define the feature macro, but its own `arm_neon.h` provides the rounding intrinsics whenever `__ARM_ARCH >= 8`.

Teach CastXML to add the `__ARM_FEATURE_DIRECTED_ROUNDING` definition whenever the compiler's predefined macros include `__ARM_ARCH >= 8` so that the `arm_neon.h` intrinsics header we distribute will provide the rounding intrinsics.

Fixes: #223