### PR TITLE
Fix tests on 32 bit architectures (offset="64" vs. offset="32")

### DIFF
--- a/test/expect/castxml1.any.Field-init.xml.txt
+++ b/test/expect/castxml1.any.Field-init.xml.txt
@@ -2,7 +2,7 @@
 <CastXML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field_int" type="_9" init="123" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="field_str" type="_10" init="&quot;abc&quot;" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64"/>
+  <Field id="_4" name="field_str" type="_10" init="&quot;abc&quot;" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
     <Argument type="_11" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.Field-init.xml.txt
+++ b/test/expect/gccxml.any.Field-init.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field_int" type="_9" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="field_str" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64"/>
+  <Field id="_4" name="field_str" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
     <Argument type="_11" location="f1:1" file="f1" line="1"/>


### PR DESCRIPTION
Fixes test failures on ix86:

The following tests FAILED:
	1366 - gccxml.c++11.Field-init (Failed)
	1367 - castxml1.c++11.Field-init (Failed)
	1368 - gccxml.gnu++11.Field-init (Failed)
	1369 - castxml1.gnu++11.Field-init (Failed)
	1370 - gccxml.c++14.Field-init (Failed)
	1371 - castxml1.c++14.Field-init (Failed)
	1372 - gccxml.gnu++14.Field-init (Failed)
	1373 - castxml1.gnu++14.Field-init (Failed)
	1374 - gccxml.c++17.Field-init (Failed)
	1375 - castxml1.c++17.Field-init (Failed)
	1376 - gccxml.gnu++17.Field-init (Failed)
	1377 - castxml1.gnu++17.Field-init (Failed)
