### PR TITLE
test: Fix test output conversion Field offset values

### DIFF
--- a/test/expect/castxml1.any.Field-init.xml.txt
+++ b/test/expect/castxml1.any.Field-init.xml.txt
@@ -2,7 +2,7 @@
 <CastXML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field_int" type="_9" init="123" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="field_str" type="_10" init="&quot;abc&quot;" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64"/>
+  <Field id="_4" name="field_str" type="_10" init="&quot;abc&quot;" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
     <Argument type="_11" location="f1:1" file="f1" line="1"/>

--- a/test/expect/castxml1.any.Field.xml.txt
+++ b/test/expect/castxml1.any.Field.xml.txt
@@ -2,7 +2,7 @@
 <CastXML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:4" file="f1" line="4" offset="32"/>
+  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:5" file="f1" line="5" offset="64" mutable="1"/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:8" file="f1" line="8">
     <Argument type="_12" location="f1:8" file="f1" line="8"/>

--- a/test/expect/gccxml.any.Comment-Field.xml.txt
+++ b/test/expect/gccxml.any.Comment-Field.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="0"/>
-  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:6" file="f1" line="6" offset="32"/>
+  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:6" file="f1" line="6" offset="[0-9]+"/>
   <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:8" file="f1" line="8" offset="64" mutable="1"/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:11" file="f1" line="11">
     <Argument type="_12" location="f1:11" file="f1" line="11"/>

--- a/test/expect/gccxml.any.Field-init.xml.txt
+++ b/test/expect/gccxml.any.Field-init.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field_int" type="_9" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="field_str" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="64"/>
+  <Field id="_4" name="field_str" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
     <Argument type="_11" location="f1:1" file="f1" line="1"/>

--- a/test/expect/gccxml.any.Field.xml.txt
+++ b/test/expect/gccxml.any.Field.xml.txt
@@ -2,7 +2,7 @@
 <GCC_XML[^>]*>
   <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:4" file="f1" line="4" offset="32"/>
+  <Field id="_4" name="bit_field" type="_11" bits="2" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Field id="_5" name="mutable_field" type="_10" context="_1" access="private" location="f1:5" file="f1" line="5" offset="64" mutable="1"/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:8" file="f1" line="8">
     <Argument type="_12" location="f1:8" file="f1" line="8"/>

--- a/test/run.cmake
+++ b/test/run.cmake
@@ -97,6 +97,7 @@ if(msg)
     string(REGEX REPLACE "artificial=\"1\"( throw=\"\")?" "artificial=\"1\"( throw=\"\")?" update_xml "${update_xml}")
     string(REGEX REPLACE "size=\"[0-9]+\" align=\"[0-9]+\"" "size=\"[0-9]+\" align=\"[0-9]+\"" update_xml "${update_xml}")
     string(REGEX REPLACE "<File id=\"(f[0-9]+)\" name=\"[^\"]*/test/input/([^\"]*)\"/>" "<File id=\"\\1\" name=\".*/test/input/\\2\"/>" update_xml "${update_xml}")
+    string(REGEX REPLACE "<Field([^>]*) offset=\"[1-9][0-9]*\"/>" "<Field\\1 offset=\"[0-9]+\"/>" update_xml "${update_xml}")
     if(update_xml MATCHES "<Base.*<Base") # multiple inheritance has ABI-specific offsets
       string(REGEX REPLACE "<Base type=\"([^\"]*)\" access=\"([^\"]*)\" virtual=\"0\" offset=\"[0-9]+\"/>" "<Base type=\"\\1\" access=\"\\2\" virtual=\"0\" offset=\"[0-9]+\"/>" update_xml "${update_xml}")
     endif()


### PR DESCRIPTION
When using `TEST_UPDATE` to convert the actual test output to the expected test output, convert non-zero Field `offset=""` values to a regex matching any offset.  This makes the output robust to the ABI's type sizes and padding.  We already do this for Base offsets in cases of multiple inheritance.

Supersedes: #230  