### PR TITLE
test: Tolerate '-internal-*' flags after '-isystem' flags

### DIFF
--- a/test/expect/cmd.cc-msvc-c-src-c-cmd.stderr.txt
+++ b/test/expect/cmd.cc-msvc-c-src-c-cmd.stderr.txt
@@ -1,1 +1,1 @@
-"clang" .* "-[^i][^"]*" "[^-"][^"]*" "-isystem" "/some/include" "-isystem" "/some/other/include" "-[^i]
+"clang" .* "-[^i][^"]*" "[^-"][^"]*" "-isystem" "/some/include" "-isystem" "/some/other/include" "-([^i]|i[^s])

--- a/test/expect/cmd.cc-msvc-src-cxx-cmd.stderr.txt
+++ b/test/expect/cmd.cc-msvc-src-cxx-cmd.stderr.txt
@@ -1,1 +1,1 @@
-"clang" .* "-[^i][^"]*" "[^-"][^"]*" "-isystem" "/some/include" "-isystem" "/some/other/include" "-[^i]
+"clang" .* "-[^i][^"]*" "[^-"][^"]*" "-isystem" "/some/include" "-isystem" "/some/other/include" "-([^i]|i[^s])


### PR DESCRIPTION
The LLVM/Clang package against which CastXML is built may be configured to add `-internal-isystem /usr/local/include` or similar flags.  Update the expected output from `cmd.cc-msvc.*cmd` tests to tolerate them after the intended `-isystem` flags.

Fixes: #234  