### PR TITLE
Output: Generate RValueReferenceType elements in castxml output format

### DIFF
--- a/doc/manual/castxml.xsd
+++ b/doc/manual/castxml.xsd
@@ -389,6 +389,14 @@
         </xs:complexType>
       </xs:element>
 
+      <xs:element name="RValueReferenceType">
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:ID" />
+          <xs:attribute name="type" type="xs:IDREF" />
+          <xs:attributeGroup ref="abi" />
+        </xs:complexType>
+      </xs:element>
+
       <xs:element name="ArrayType">
         <xs:complexType>
           <xs:attribute name="id" type="xs:ID" />

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -698,43 +698,40 @@ ASTVisitor::DumpId ASTVisitor::AddDeclDumpNode(clang::Decl const* d,
     return DumpId();
   }
 
-  // Skip C++11 declarations gccxml does not support.
-  if (this->Opts.GccXml || this->Opts.CastXml) {
-    if (clang::FunctionDecl const* fd =
-          clang::dyn_cast<clang::FunctionDecl>(d)) {
-      if (fd->isDeleted()) {
-        return DumpId();
-      }
-
-      if (fd->getLiteralIdentifier()) {
-        return DumpId();
-      }
-
-      if (clang::FunctionProtoType const* fpt =
-            fd->getType()->getAs<clang::FunctionProtoType>()) {
-        if (fpt->getReturnType()->isRValueReferenceType()) {
-          return DumpId();
-        }
-        for (clang::FunctionProtoType::param_type_iterator
-               i = fpt->param_type_begin(),
-               e = fpt->param_type_end();
-             i != e; ++i) {
-          if ((*i)->isRValueReferenceType()) {
-            return DumpId();
-          }
-        }
-      }
-    }
-
-    if (clang::dyn_cast<clang::TypeAliasTemplateDecl>(d)) {
+  // Skip declarations our output formats do not support.
+  if (clang::FunctionDecl const* fd =
+        clang::dyn_cast<clang::FunctionDecl>(d)) {
+    if (fd->isDeleted()) {
       return DumpId();
     }
 
-    if (clang::TypedefDecl const* td =
-          clang::dyn_cast<clang::TypedefDecl>(d)) {
-      if (td->getUnderlyingType()->isRValueReferenceType()) {
+    if (fd->getLiteralIdentifier()) {
+      return DumpId();
+    }
+
+    if (clang::FunctionProtoType const* fpt =
+          fd->getType()->getAs<clang::FunctionProtoType>()) {
+      if (fpt->getReturnType()->isRValueReferenceType()) {
         return DumpId();
       }
+      for (clang::FunctionProtoType::param_type_iterator
+             i = fpt->param_type_begin(),
+             e = fpt->param_type_end();
+           i != e; ++i) {
+        if ((*i)->isRValueReferenceType()) {
+          return DumpId();
+        }
+      }
+    }
+  }
+
+  if (clang::dyn_cast<clang::TypeAliasTemplateDecl>(d)) {
+    return DumpId();
+  }
+
+  if (clang::TypedefDecl const* td = clang::dyn_cast<clang::TypedefDecl>(d)) {
+    if (td->getUnderlyingType()->isRValueReferenceType()) {
+      return DumpId();
     }
   }
 

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -583,6 +583,8 @@ class ASTVisitor : public ASTVisitorBase
                                DumpNode const* dn);
   void OutputLValueReferenceType(clang::LValueReferenceType const* t,
                                  DumpNode const* dn);
+  void OutputRValueReferenceType(clang::RValueReferenceType const* t,
+                                 DumpNode const* dn);
   void OutputMemberPointerType(clang::MemberPointerType const* t,
                                DumpNode const* dn);
   void OutputMethodType(clang::FunctionProtoType const* t,
@@ -729,9 +731,12 @@ ASTVisitor::DumpId ASTVisitor::AddDeclDumpNode(clang::Decl const* d,
     return DumpId();
   }
 
-  if (clang::TypedefDecl const* td = clang::dyn_cast<clang::TypedefDecl>(d)) {
-    if (td->getUnderlyingType()->isRValueReferenceType()) {
-      return DumpId();
+  if (this->Opts.GccXml) {
+    if (clang::TypedefDecl const* td =
+          clang::dyn_cast<clang::TypedefDecl>(d)) {
+      if (td->getUnderlyingType()->isRValueReferenceType()) {
+        return DumpId();
+      }
     }
   }
 
@@ -2372,6 +2377,16 @@ void ASTVisitor::OutputLValueReferenceType(clang::LValueReferenceType const* t,
                                            DumpNode const* dn)
 {
   this->OS << "  <ReferenceType";
+  this->PrintIdAttribute(dn);
+  this->PrintTypeAttribute(t->getPointeeType(), false);
+  this->PrintABIAttributes(this->CTX.getTypeInfo(t));
+  this->OS << "/>\n";
+}
+
+void ASTVisitor::OutputRValueReferenceType(clang::RValueReferenceType const* t,
+                                           DumpNode const* dn)
+{
+  this->OS << "  <RValueReferenceType";
   this->PrintIdAttribute(dn);
   this->PrintTypeAttribute(t->getPointeeType(), false);
   this->PrintABIAttributes(this->CTX.getTypeInfo(t));

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -711,17 +711,19 @@ ASTVisitor::DumpId ASTVisitor::AddDeclDumpNode(clang::Decl const* d,
       return DumpId();
     }
 
-    if (clang::FunctionProtoType const* fpt =
-          fd->getType()->getAs<clang::FunctionProtoType>()) {
-      if (fpt->getReturnType()->isRValueReferenceType()) {
-        return DumpId();
-      }
-      for (clang::FunctionProtoType::param_type_iterator
-             i = fpt->param_type_begin(),
-             e = fpt->param_type_end();
-           i != e; ++i) {
-        if ((*i)->isRValueReferenceType()) {
+    if (this->Opts.GccXml) {
+      if (clang::FunctionProtoType const* fpt =
+            fd->getType()->getAs<clang::FunctionProtoType>()) {
+        if (fpt->getReturnType()->isRValueReferenceType()) {
           return DumpId();
+        }
+        for (clang::FunctionProtoType::param_type_iterator
+               i = fpt->param_type_begin(),
+               e = fpt->param_type_end();
+             i != e; ++i) {
+          if ((*i)->isRValueReferenceType()) {
+            return DumpId();
+          }
         }
       }
     }

--- a/test/expect/castxml1.any.Class-annotate.xml.txt
+++ b/test/expect/castxml1.any.Class-annotate.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+" annotation="an annotation" attributes="annotate\(an annotation\)"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-annotate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-base-offset.xml.txt
+++ b/test/expect/castxml1.any.Class-base-offset.xml.txt
@@ -1,11 +1,89 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:13" file="f1" line="13" members="_3 _4 _5 _6" bases="_7 _8 _9" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="0"/>
-    <Base type="_8" access="public" virtual="0" offset="1"/>
-    <Base type="_9" access="public" virtual="0" offset="2"/>
+  <Class id="_1" name="start" context="_2" location="f1:13" file="f1" line="13" members="_3 _4 _5 _6 _7 _8" bases="_9 _10 _11" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_11" access="public" virtual="0" offset="[0-9]+"/>
   </Class>
-.*
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?>
+    <Argument type="_12" location="f1:13" file="f1" line="13"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_13" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:13" file="f1" line="13"/>
+  </OperatorMethod>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:13" file="f1" line="13"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:13" file="f1" line="13"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="base_1" context="_2" location="f1:1" file="f1" line="1" members="_15 _16 _17 _18 _19 _20 _21" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="base_2" context="_2" location="f1:5" file="f1" line="5" members="_22 _23 _24 _25 _26 _27 _28" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_11" name="base_3" context="_2" location="f1:9" file="f1" line="9" members="_29 _30 _31 _32 _33 _34 _35" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_15" name="b1" type="_36" context="_9" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Constructor id="_16" name="base_1" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_17" name="base_1" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_37" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_18" name="=" returns="_38" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_37" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Constructor id="_19" name="base_1" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_39" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_20" name="=" returns="_38" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_39" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_21" name="base_1" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Field id="_22" name="b2" type="_36" context="_10" access="private" location="f1:7" file="f1" line="7" offset="0"/>
+  <Constructor id="_23" name="base_2" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_24" name="base_2" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_40" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_25" name="=" returns="_41" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_40" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Constructor id="_26" name="base_2" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_42" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_27" name="=" returns="_41" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_42" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_28" name="base_2" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Field id="_29" name="b3" type="_36" context="_11" access="private" location="f1:11" file="f1" line="11" offset="0"/>
+  <Constructor id="_30" name="base_3" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_31" name="base_3" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_43" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_32" name="=" returns="_44" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_43" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Constructor id="_33" name="base_3" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_45" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_34" name="=" returns="_44" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_45" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Destructor id="_35" name="base_3" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_36" name="char" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_37" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_38" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_39" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_40" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <ReferenceType id="_41" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_42" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_43" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <ReferenceType id="_44" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_45" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-base-offset.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-base-typedef.xml.txt
+++ b/test/expect/castxml1.any.Class-base-typedef.xml.txt
@@ -1,31 +1,45 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6" bases="_7" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8" bases="_9" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="0"/>
   </Class>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
-    <Argument type="_8" location="f1:5" file="f1" line="5"/>
+    <Argument type="_10" location="f1:5" file="f1" line="5"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_9" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_8" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_5" name="=" returns="_11" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Class id="_7" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _11 _12 _13" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="base" context="_2" location="f1:1" file="f1" line="1" members="_13 _14 _15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_10" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_11" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_13" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_14" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_19" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_12" name="=" returns="_15" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_15" name="=" returns="_20" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_19" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_13" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_14" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_15" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_16" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_21" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_17" name="=" returns="_20" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_21" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_18" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_19" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_20" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_21" type="_9" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-base-typedef.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-deprecated-long.xml.txt
+++ b/test/expect/castxml1.any.Class-deprecated-long.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" deprecation="Deprecated: Additional information about the deprecation of &apos;start&apos;which spreads over multiple lines &lt;this is more infomation&gt; can be found &quot;online&quot; " attributes="deprecated"/>
+  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+" deprecation="Deprecated: Additional information about the deprecation of &apos;start&apos;which spreads over multiple lines &lt;this is more infomation&gt; can be found &quot;online&quot; " attributes="deprecated"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:4" file="f1" line="4"/>
+    <Argument type="_9" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:4" file="f1" line="4"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-deprecated-long.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-deprecated.xml.txt
+++ b/test/expect/castxml1.any.Class-deprecated.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" deprecation="Class Deprecated" attributes="deprecated"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+" deprecation="Class Deprecated" attributes="deprecated"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-deprecated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-friends.xml.txt
+++ b/test/expect/castxml1.any.Class-friends.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6" befriending="_7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8" befriending="_9 _10" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:5" file="f1" line="5"/>
+    <Argument type="_11" location="f1:5" file="f1" line="5"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_5" name="=" returns="_12" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
-  <Function id="_7" name="f" returns="_11" context="_2" location="f1:4" file="f1" line="4" mangled="[^"]+"/>
-  <ElaboratedType id="_8" keyword="class" type="_12"/>
-  <FundamentalType id="_11" name="void" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_12" name="A" context="_2" location="f1:1" file="f1" line="1" size="[0-9]+" align="[0-9]+"/>
+  <Function id="_9" name="f" returns="_14" context="_2" location="f1:4" file="f1" line="4" mangled="[^"]+"/>
+  <ElaboratedType id="_10" keyword="class" type="_15"/>
+  <FundamentalType id="_14" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_15" name="A" context="_2" location="f1:1" file="f1" line="1" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Class-friends.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-implicit-member-array.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-array.xml.txt
@@ -1,20 +1,27 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ArrayType id="_8" min="0" max="1" type="_11"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ArrayType id="_10" min="0" max="1" type="_14"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_14" name="int" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-array.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-implicit-member-bad-base.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-bad-base.xml.txt
@@ -1,30 +1,37 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5" bases="_6" size="[0-9]+" align="[0-9]+">
-    <Base type="_6" access="public" virtual="0" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6" bases="_7" size="[0-9]+" align="[0-9]+">
+    <Base type="_7" access="public" virtual="0" offset="0"/>
   </Class>
-  (<Constructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:9" file="f1" line="9"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_8" location="f1:9" file="f1" line="9"/>
   </Constructor>
-  |<Constructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:9" file="f1" line="9"/>
+  (<Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:9" file="f1" line="9"/>
   </Constructor>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
-  )<Destructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
-  <Class id="_6" name="base&lt;const int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_8 _9 _10 _11" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  |<Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  )<Destructor id="_6" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Class id="_7" name="base&lt;const int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_10 _11 _12 _13" size="[0-9]+" align="[0-9]+"/>
+  (<RValueReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <Field id="_8" name="data" type="_12c" context="_6" access="protected" location="f1:5" file="f1" line="5" offset="0"/>
-  <Constructor id="_9" name="base" context="_6" access="protected" location="f1:6" file="f1" line="6"/>
-  <Constructor id="_10" name="base" context="_6" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
-    <Argument type="_13" location="f1:2" file="f1" line="2"/>
+  |<ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
+  )<Field id="_10" name="data" type="_14c" context="_7" access="protected" location="f1:5" file="f1" line="5" offset="0"/>
+  <Constructor id="_11" name="base" context="_7" access="protected" location="f1:6" file="f1" line="6"/>
+  <Constructor id="_12" name="base" context="_7" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:2" file="f1" line="2"/>
   </Constructor>
-  <Destructor id="_11" name="base" context="_6" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_12c" type="_12" const="1"/>
-  <ReferenceType id="_13" type="_6c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_6c" type="_6" const="1"/>
+  <Destructor id="_13" name="base" context="_7" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_14" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_14c" type="_14" const="1"/>
+  <ReferenceType id="_15" type="_7c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_7c" type="_7" const="1"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-bad-base.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-implicit-member-const-aggregate.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-const-aggregate.xml.txt
@@ -1,15 +1,19 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Struct id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="data" type="_6c" context="_1" access="public" location="f1:3" file="f1" line="3" offset="0"/>
+  <Struct id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_7c" context="_1" access="public" location="f1:3" file="f1" line="3" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_8" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <Destructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_6c" type="_6" const="1"/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_7c" type="_7" const="1"/>
+  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-const-aggregate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-implicit-member-const.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-const.xml.txt
@@ -1,16 +1,20 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="data" type="_7c" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_8c" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-const.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-implicit-member-reference.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-member-reference.xml.txt
@@ -1,16 +1,20 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="ref" type="_7" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="ref" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Class-implicit-member-reference.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-implicit-members.xml.txt
+++ b/test/expect/castxml1.any.Class-implicit-members.xml.txt
@@ -1,20 +1,27 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Method id="_3" name="method" returns="_1" context="_1" access="private" location="f1:3" file="f1" line="3" inline="1" mangled="[^"]+">
-    <Argument name="x" type="_8" location="f1:3" file="f1" line="3"/>
+    <Argument name="x" type="_10" location="f1:3" file="f1" line="3"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_9" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-implicit-members.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-member-Struct-anonymous.xml.txt
+++ b/test/expect/castxml1.any.Class-member-Struct-anonymous.xml.txt
@@ -1,31 +1,45 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Struct id="_3" name="" context="_1" access="private" location="f1:3" file="f1" line="3" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_4" name="s" type="_13" context="_1" access="private" location="f1:5" file="f1" line="5" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_3" name="" context="_1" access="private" location="f1:3" file="f1" line="3" members="_11 _12 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_4" name="s" type="_17" context="_1" access="private" location="f1:5" file="f1" line="5" offset="0"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_19" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_9" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_10" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
-    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_20" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_11" name="=" returns="_17" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  <OperatorMethod id="_9" name="=" returns="_19" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_20" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_12" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
-  <ElaboratedType id="_13" keyword="struct" type="_3"/>
-  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_11" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_12" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
+    <Argument type="_21" location="f1:3" file="f1" line="3"/>
+  </Constructor>
+  <OperatorMethod id="_13" name="=" returns="_22" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_21" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Constructor id="_14" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:3" file="f1" line="3"/>
+  </Constructor>
+  <OperatorMethod id="_15" name="=" returns="_22" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Destructor id="_16" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <ElaboratedType id="_17" keyword="struct" type="_3"/>
+  <ReferenceType id="_18" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_16" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_19" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_20" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_21" type="_3c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_3c" type="_3" const="1"/>
-  <ReferenceType id="_17" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_22" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_23" type="_3" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-member-Struct-anonymous.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-member-Union-anonymous.xml.txt
+++ b/test/expect/castxml1.any.Class-member-Union-anonymous.xml.txt
@@ -1,31 +1,45 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Union id="_3" name="" context="_1" access="private" location="f1:3" file="f1" line="3" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_4" name="u" type="_13" context="_1" access="private" location="f1:5" file="f1" line="5" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Union id="_3" name="" context="_1" access="private" location="f1:3" file="f1" line="3" members="_11 _12 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_4" name="u" type="_17" context="_1" access="private" location="f1:5" file="f1" line="5" offset="0"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_19" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_9" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_10" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
-    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_20" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_11" name="=" returns="_17" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  <OperatorMethod id="_9" name="=" returns="_19" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_20" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_12" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
-  <ElaboratedType id="_13" keyword="union" type="_3"/>
-  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_11" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_12" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
+    <Argument type="_21" location="f1:3" file="f1" line="3"/>
+  </Constructor>
+  <OperatorMethod id="_13" name="=" returns="_22" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_21" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Constructor id="_14" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:3" file="f1" line="3"/>
+  </Constructor>
+  <OperatorMethod id="_15" name="=" returns="_22" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Destructor id="_16" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <ElaboratedType id="_17" keyword="union" type="_3"/>
+  <ReferenceType id="_18" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_16" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_19" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_20" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_21" type="_3c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_3c" type="_3" const="1"/>
-  <ReferenceType id="_17" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_22" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_23" type="_3" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-member-Union-anonymous.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-member-template-access.xml.txt
+++ b/test/expect/castxml1.any.Class-member-template-access.xml.txt
@@ -1,31 +1,45 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10 _11" size="[0-9]+" align="[0-9]+"/>
   <Class id="_3" name="member&lt;char&gt;" context="_1" access="private" location="f1:4" file="f1" line="4" incomplete="1"/>
-  <Class id="_4" name="member&lt;int&gt;" context="_1" access="private" location="f1:11" file="f1" line="11" members="_10 _11 _12 _13" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_4" name="member&lt;int&gt;" context="_1" access="private" location="f1:11" file="f1" line="11" members="_12 _13 _14 _15 _16 _17" size="[0-9]+" align="[0-9]+"/>
   <Typedef id="_5" name="member_char" type="_3" context="_1" access="public" location="f1:9" file="f1" line="9"/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_8" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_8" name="=" returns="_19" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_10" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_11" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
-    <Argument type="_16" location="f1:11" file="f1" line="11"/>
+  <Constructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_20" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_12" name="=" returns="_17" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_16" location="f1:11" file="f1" line="11"/>
+  <OperatorMethod id="_10" name="=" returns="_19" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_20" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_13" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_11" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_12" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_13" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_21" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_14" name="=" returns="_22" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_21" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Constructor id="_15" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_16" name="=" returns="_22" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_17" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_18" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_16" type="_4c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_19" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_20" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_21" type="_4c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_4c" type="_4" const="1"/>
-  <ReferenceType id="_17" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_22" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_23" type="_4" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-member-template-access.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-member-template.xml.txt
+++ b/test/expect/castxml1.any.Class-member-template.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" inline="1" mangled="[^"]+">
-    <Argument name="v" type="_8" location="f1:4" file="f1" line="4"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:4" file="f1" line="4" inline="1" mangled="[^"]+">
+    <Argument name="v" type="_10" location="f1:4" file="f1" line="4"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-member-template.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.any.Class-ms-dllexport.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" attributes="dllexport"/>
-  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?( attributes="dllexport")?/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?( attributes="dllexport")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+" attributes="dllexport"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllexport">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllexport">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?( attributes="dllexport")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllexport">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-ms-dllexport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.any.Class-ms-dllimport.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" attributes="dllimport"/>
-  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?( attributes="dllimport")?/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?( attributes="dllimport")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+" attributes="dllimport"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllimport">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllimport">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?( attributes="dllimport")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllimport">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-ms-dllimport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-partial-template-member-Typedef.xml.txt
+++ b/test/expect/castxml1.any.Class-partial-template-member-Typedef.xml.txt
@@ -1,22 +1,29 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int &amp;&gt;" context="_2" location="f1:11" file="f1" line="11" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Typedef id="_3" name="Int" type="_9" context="_1" access="private" location="f1:6" file="f1" line="6"/>
-  <Method id="_4" name="method" returns="_9" context="_1" access="public" location="f1:9" file="f1" line="9" mangled="[^"]+">
+  <Class id="_1" name="start&lt;int &amp;&gt;" context="_2" location="f1:11" file="f1" line="11" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_3" name="Int" type="_11" context="_1" access="private" location="f1:6" file="f1" line="6"/>
+  <Method id="_4" name="method" returns="_11" context="_1" access="public" location="f1:9" file="f1" line="9" mangled="[^"]+">
     <Argument type="_3" location="f1:9" file="f1" line="9"/>
   </Method>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:11" file="f1" line="11"/>
+    <Argument type="_12" location="f1:11" file="f1" line="11"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:11" file="f1" line="11"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:11" file="f1" line="11"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_13" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-partial-template-member-Typedef.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-Method-Argument-const.xml.txt
+++ b/test/expect/castxml1.any.Class-template-Method-Argument-const.xml.txt
@@ -1,24 +1,31 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
-    <Argument type="_9" location="f1:4" file="f1" line="4"/>
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_11" location="f1:4" file="f1" line="4"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:6" file="f1" line="6"/>
+    <Argument type="_12" location="f1:6" file="f1" line="6"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_11" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:6" file="f1" line="6"/>
+  <OperatorMethod id="_6" name="=" returns="_13" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:6" file="f1" line="6"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="void" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_12c" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_13" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="void" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_15c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_12c" type="_12" const="1"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_15c" type="_15" const="1"/>
   <Namespace id="_2" name="::"/>
-  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_15" name="int" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Class-template-Method-Argument-const.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-Method-Argument-default.xml.txt
+++ b/test/expect/castxml1.any.Class-template-Method-Argument-default.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
-    <Argument type="_8" location="f1:4" file="f1" line="4" default="123"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_10" location="f1:4" file="f1" line="4" default="123"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+    <Argument type="_11" location="f1:6" file="f1" line="6"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:6" file="f1" line="6"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-Method-Argument-default.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-Method-return-const.xml.txt
+++ b/test/expect/castxml1.any.Class-template-Method-return-const.xml.txt
@@ -1,20 +1,27 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8c" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+"/>
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10c" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+    <Argument type="_11" location="f1:6" file="f1" line="6"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:6" file="f1" line="6"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-Method-return-const.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-friends.xml.txt
+++ b/test/expect/castxml1.any.Class-template-friends.xml.txt
@@ -1,23 +1,30 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:13" file="f1" line="13" members="_3 _4 _5 _6" befriending="_7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:13" file="f1" line="13" members="_3 _4 _5 _6 _7 _8" befriending="_9 _10" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:13" file="f1" line="13"/>
+    <Argument type="_11" location="f1:13" file="f1" line="13"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:13" file="f1" line="13"/>
+  <OperatorMethod id="_5" name="=" returns="_12" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:13" file="f1" line="13"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:13" file="f1" line="13"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:13" file="f1" line="13"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
-  <Function id="_7" name="f" returns="_11" context="_2" location="f1:9" file="f1" line="9" mangled="[^"]+">
-    <Argument type="_11" location="f1:4" file="f1" line="4"/>
+  <Function id="_9" name="f" returns="_14" context="_2" location="f1:9" file="f1" line="9" mangled="[^"]+">
+    <Argument type="_14" location="f1:4" file="f1" line="4"/>
   </Function>
-  <ElaboratedType id="_8" keyword="class" type="_12"/>
-  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_12" name="A&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" incomplete="1"/>
+  <ElaboratedType id="_10" keyword="class" type="_15"/>
+  <FundamentalType id="_14" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_15" name="A&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" incomplete="1"/>
   <File id="f1" name=".*/test/input/Class-template-friends.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-member-Typedef-const.xml.txt
+++ b/test/expect/castxml1.any.Class-template-member-Typedef-const.xml.txt
@@ -1,23 +1,30 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Typedef id="_3" name="IntConst" type="_9c" context="_1" access="private" location="f1:4" file="f1" line="4"/>
-  <Method id="_4" name="method" returns="_9c" context="_1" access="public" location="f1:7" file="f1" line="7" mangled="[^"]+">
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_3" name="IntConst" type="_11c" context="_1" access="private" location="f1:4" file="f1" line="4"/>
+  <Method id="_4" name="method" returns="_11c" context="_1" access="public" location="f1:7" file="f1" line="7" mangled="[^"]+">
     <Argument type="_3" location="f1:7" file="f1" line="7"/>
   </Method>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+    <Argument type="_12" location="f1:9" file="f1" line="9"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:9" file="f1" line="9"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_9c" type="_9" const="1"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_13" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-member-Typedef-const.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-member-Typedef.xml.txt
+++ b/test/expect/castxml1.any.Class-template-member-Typedef.xml.txt
@@ -1,22 +1,29 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Typedef id="_3" name="Int" type="_9" context="_1" access="private" location="f1:4" file="f1" line="4"/>
-  <Method id="_4" name="method" returns="_9" context="_1" access="public" location="f1:7" file="f1" line="7" mangled="[^"]+">
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_3" name="Int" type="_11" context="_1" access="private" location="f1:4" file="f1" line="4"/>
+  <Method id="_4" name="method" returns="_11" context="_1" access="public" location="f1:7" file="f1" line="7" mangled="[^"]+">
     <Argument type="_3" location="f1:7" file="f1" line="7"/>
   </Method>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+    <Argument type="_12" location="f1:9" file="f1" line="9"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:9" file="f1" line="9"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_13" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-member-Typedef.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-member-template.xml.txt
+++ b/test/expect/castxml1.any.Class-template-member-template.xml.txt
@@ -1,22 +1,29 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:5" file="f1" line="5" inline="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:5" file="f1" line="5"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:5" file="f1" line="5" inline="1" mangled="[^"]+">
+    <Argument type="_11" location="f1:5" file="f1" line="5"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+    <Argument type="_12" location="f1:2" file="f1" line="2"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_11" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+  <OperatorMethod id="_6" name="=" returns="_13" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:2" file="f1" line="2"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="char" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:2" file="f1" line="2"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_13" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:2" file="f1" line="2"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="char" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-member-template.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template-recurse.xml.txt
+++ b/test/expect/castxml1.any.Class-template-recurse.xml.txt
@@ -1,18 +1,25 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
   <Variable id="_1" name="start" type="_2" init="" context="_3" location="f1:20" file="f1" line="20"/>
-  <Struct id="_2" name="C&lt;void&gt;" context="_3" location="f1:11" file="f1" line="11" members="_4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_2" name="C&lt;void&gt;" context="_3" location="f1:11" file="f1" line="11" members="_4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_4" name="C" context="_2" access="public" location="f1:13" file="f1" line="13" inline="1"/>
   <Constructor id="_5" name="C" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
-    <Argument type="_8" location="f1:11" file="f1" line="11"/>
+    <Argument type="_10" location="f1:11" file="f1" line="11"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_9" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_8" location="f1:11" file="f1" line="11"/>
+  <Constructor id="_6" name="C" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:11" file="f1" line="11"/>
   </OperatorMethod>
-  <Destructor id="_7" name="C" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_2c" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="C" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_2c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_2c" type="_2" const="1"/>
-  <ReferenceType id="_9" type="_2" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_2" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_2" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-recurse.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class-template.xml.txt
+++ b/test/expect/castxml1.any.Class-template.xml.txt
@@ -1,30 +1,44 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
   <Class id="_1" name="start&lt;char&gt;" context="_4" location="f1:10" file="f1" line="10" incomplete="1"/>
-  <Class id="_2" name="start&lt;int&gt;" context="_4" location="f1:11" file="f1" line="11" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Struct id="_3" name="start&lt;int &amp;&gt;" context="_4" location="f1:12" file="f1" line="12" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_2" name="start&lt;int&gt;" context="_4" location="f1:11" file="f1" line="11" members="_5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_3" name="start&lt;int &amp;&gt;" context="_4" location="f1:12" file="f1" line="12" members="_11 _12 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_5" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
-    <Argument type="_13" location="f1:11" file="f1" line="11"/>
+    <Argument type="_17" location="f1:11" file="f1" line="11"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_14" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_13" location="f1:11" file="f1" line="11"/>
+  <OperatorMethod id="_7" name="=" returns="_18" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_17" location="f1:11" file="f1" line="11"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_9" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_10" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
-    <Argument type="_15" location="f1:12" file="f1" line="12"/>
+  <Constructor id="_8" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_19" location="f1:11" file="f1" line="11"/>
   </Constructor>
-  <OperatorMethod id="_11" name="=" returns="_16" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_15" location="f1:12" file="f1" line="12"/>
+  <OperatorMethod id="_9" name="=" returns="_18" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_19" location="f1:11" file="f1" line="11"/>
   </OperatorMethod>
-  <Destructor id="_12" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_13" type="_2c" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_10" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_11" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_12" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
+    <Argument type="_20" location="f1:12" file="f1" line="12"/>
+  </Constructor>
+  <OperatorMethod id="_13" name="=" returns="_21" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_20" location="f1:12" file="f1" line="12"/>
+  </OperatorMethod>
+  <Constructor id="_14" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
+    <Argument type="_22" location="f1:12" file="f1" line="12"/>
+  </Constructor>
+  <OperatorMethod id="_15" name="=" returns="_21" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_22" location="f1:12" file="f1" line="12"/>
+  </OperatorMethod>
+  <Destructor id="_16" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_17" type="_2c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_2c" type="_2" const="1"/>
-  <ReferenceType id="_14" type="_2" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_15" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_18" type="_2" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_19" type="_2" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_20" type="_3c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_3c" type="_3" const="1"/>
-  <ReferenceType id="_16" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_21" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_22" type="_3" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_4" name="::"/>
   <File id="f1" name=".*/test/input/Class-template.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Class.xml.txt
+++ b/test/expect/castxml1.any.Class.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Comment-Method.xml.txt
+++ b/test/expect/castxml1.any.Comment-Method.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+" comment="c1">
-    <Argument type="_8" location="f1:4" file="f1" line="4"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+" comment="c1">
+    <Argument type="_10" location="f1:4" file="f1" line="4"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <Comment id="c1" attached="_3" file="f1" begin_line="3" begin_column="3" begin_offset="16" end_line="3" end_column="24" end_offset="37"/>
   <File id="f1" name=".*/test/input/Comment-Method.cxx"/>

--- a/test/expect/castxml1.any.Constructor-annotate.xml.txt
+++ b/test/expect/castxml1.any.Constructor-annotate.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" annotation="an annotation" attributes="annotate\(an annotation\)"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Constructor-annotate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Constructor-deprecated.xml.txt
+++ b/test/expect/castxml1.any.Constructor-deprecated.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" deprecation="Constructor Deprecated" attributes="deprecated"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Constructor-deprecated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Constructor-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.any.Constructor-ms-dllexport.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" attributes="dllexport"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Constructor-ms-dllexport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Constructor-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.any.Constructor-ms-dllimport.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" attributes="dllimport"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Constructor-ms-dllimport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Constructor.xml.txt
+++ b/test/expect/castxml1.any.Constructor.xml.txt
@@ -1,17 +1,24 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Constructor.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Converter-annotate.xml.txt
+++ b/test/expect/castxml1.any.Converter-annotate.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Converter-annotate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Converter-deprecated.xml.txt
+++ b/test/expect/castxml1.any.Converter-deprecated.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="Converter Deprecated" attributes="deprecated"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="Converter Deprecated" attributes="deprecated"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Converter-deprecated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Converter-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.any.Converter-ms-dllexport.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Converter-ms-dllexport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Converter-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.any.Converter-ms-dllimport.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Converter-ms-dllimport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Converter.xml.txt
+++ b/test/expect/castxml1.any.Converter.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Converter.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Elaborated.xml.txt
+++ b/test/expect/castxml1.any.Elaborated.xml.txt
@@ -15,85 +15,99 @@
   <Variable id="_14" name="e4" type="_43" context="_1" location="f1:21" file="f1" line="21" mangled="[^"]+"/>
   <Typedef id="_15" name="e5" type="_40" context="_1" location="f1:22" file="f1" line="22"/>
   <Typedef id="_16" name="e6" type="_41" context="_1" location="f1:23" file="f1" line="23"/>
-  <Union id="_17" name="Foo3" context="_1" location="f1:26" file="f1" line="26" members="_44 _45 _46 _47" size="[0-9]+" align="[0-9]+"/>
-  <Variable id="_18" name="u1" type="_48" context="_1" location="f1:30" file="f1" line="30" mangled="[^"]+"/>
-  <Variable id="_19" name="u2" type="_49" context="_1" location="f1:31" file="f1" line="31" mangled="[^"]+"/>
-  <Variable id="_20" name="u3" type="_50" context="_1" location="f1:32" file="f1" line="32" mangled="[^"]+"/>
-  <Variable id="_21" name="u4" type="_51" context="_1" location="f1:33" file="f1" line="33" mangled="[^"]+"/>
-  <Typedef id="_22" name="u5" type="_48" context="_1" location="f1:34" file="f1" line="34"/>
-  <Typedef id="_23" name="u6" type="_49" context="_1" location="f1:35" file="f1" line="35"/>
-  <Class id="_24" name="Foo4" context="_1" location="f1:38" file="f1" line="38" members="_52 _53 _54 _55" size="[0-9]+" align="[0-9]+"/>
-  <Variable id="_25" name="c1" type="_56" context="_1" location="f1:42" file="f1" line="42" mangled="[^"]+"/>
-  <Variable id="_26" name="c2" type="_57" context="_1" location="f1:43" file="f1" line="43" mangled="[^"]+"/>
-  <Variable id="_27" name="c3" type="_50" context="_1" location="f1:44" file="f1" line="44" mangled="[^"]+"/>
-  <Variable id="_28" name="c4" type="_58" context="_1" location="f1:45" file="f1" line="45" mangled="[^"]+"/>
-  <Typedef id="_29" name="c5" type="_56" context="_1" location="f1:46" file="f1" line="46"/>
-  <Typedef id="_30" name="c6" type="_57" context="_1" location="f1:47" file="f1" line="47"/>
-  <Function id="_31" name="func1" returns="_59" context="_1" location="f1:50" file="f1" line="50" mangled="[^"]+">
+  <Union id="_17" name="Foo3" context="_1" location="f1:26" file="f1" line="26" members="_44 _45 _46 _47 _48 _49" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_18" name="u1" type="_50" context="_1" location="f1:30" file="f1" line="30" mangled="[^"]+"/>
+  <Variable id="_19" name="u2" type="_51" context="_1" location="f1:31" file="f1" line="31" mangled="[^"]+"/>
+  <Variable id="_20" name="u3" type="_52" context="_1" location="f1:32" file="f1" line="32" mangled="[^"]+"/>
+  <Variable id="_21" name="u4" type="_53" context="_1" location="f1:33" file="f1" line="33" mangled="[^"]+"/>
+  <Typedef id="_22" name="u5" type="_50" context="_1" location="f1:34" file="f1" line="34"/>
+  <Typedef id="_23" name="u6" type="_51" context="_1" location="f1:35" file="f1" line="35"/>
+  <Class id="_24" name="Foo4" context="_1" location="f1:38" file="f1" line="38" members="_54 _55 _56 _57 _58 _59" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_25" name="c1" type="_60" context="_1" location="f1:42" file="f1" line="42" mangled="[^"]+"/>
+  <Variable id="_26" name="c2" type="_61" context="_1" location="f1:43" file="f1" line="43" mangled="[^"]+"/>
+  <Variable id="_27" name="c3" type="_52" context="_1" location="f1:44" file="f1" line="44" mangled="[^"]+"/>
+  <Variable id="_28" name="c4" type="_62" context="_1" location="f1:45" file="f1" line="45" mangled="[^"]+"/>
+  <Typedef id="_29" name="c5" type="_60" context="_1" location="f1:46" file="f1" line="46"/>
+  <Typedef id="_30" name="c6" type="_61" context="_1" location="f1:47" file="f1" line="47"/>
+  <Function id="_31" name="func1" returns="_63" context="_1" location="f1:50" file="f1" line="50" mangled="[^"]+">
     <Argument name="a1" type="_35" location="f1:50" file="f1" line="50"/>
     <Argument name="a2" type="_36" location="f1:50" file="f1" line="50"/>
   </Function>
-  <Function id="_32" name="func2" returns="_59" context="_1" location="f1:51" file="f1" line="51" mangled="[^"]+">
+  <Function id="_32" name="func2" returns="_63" context="_1" location="f1:51" file="f1" line="51" mangled="[^"]+">
     <Argument name="a3" type="_40" location="f1:51" file="f1" line="51"/>
     <Argument name="a4" type="_41" location="f1:51" file="f1" line="51"/>
   </Function>
-  <Function id="_33" name="func3" returns="_59" context="_1" location="f1:52" file="f1" line="52" mangled="[^"]+">
-    <Argument name="a5" type="_48" location="f1:52" file="f1" line="52"/>
-    <Argument name="a6" type="_49" location="f1:52" file="f1" line="52"/>
+  <Function id="_33" name="func3" returns="_63" context="_1" location="f1:52" file="f1" line="52" mangled="[^"]+">
+    <Argument name="a5" type="_50" location="f1:52" file="f1" line="52"/>
+    <Argument name="a6" type="_51" location="f1:52" file="f1" line="52"/>
   </Function>
-  <Function id="_34" name="func4" returns="_59" context="_1" location="f1:53" file="f1" line="53" mangled="[^"]+">
-    <Argument name="a7" type="_56" location="f1:53" file="f1" line="53"/>
-    <Argument name="a8" type="_57" location="f1:53" file="f1" line="53"/>
+  <Function id="_34" name="func4" returns="_63" context="_1" location="f1:53" file="f1" line="53" mangled="[^"]+">
+    <Argument name="a7" type="_60" location="f1:53" file="f1" line="53"/>
+    <Argument name="a8" type="_61" location="f1:53" file="f1" line="53"/>
   </Function>
   <PointerType id="_35" type="_3" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_36" type="_60" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_36" type="_64" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_37" type="_3c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_3c" type="_3" const="1"/>
-  <PointerType id="_38" type="_60c" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_38" type="_64c" size="[0-9]+" align="[0-9]+"/>
   <FundamentalType id="_39" name="(unsigned )?int" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_40" type="_10" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_41" type="_61" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_41" type="_65" size="[0-9]+" align="[0-9]+"/>
   <PointerType id="_42" type="_10c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_10c" type="_10" const="1"/>
-  <PointerType id="_43" type="_61c" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_43" type="_65c" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_44" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_45" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?>
-    <Argument type="_62" location="f1:26" file="f1" line="26"/>
+    <Argument type="_66" location="f1:26" file="f1" line="26"/>
   </Constructor>
-  <OperatorMethod id="_46" name="=" returns="_63" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_62" location="f1:26" file="f1" line="26"/>
+  <OperatorMethod id="_46" name="=" returns="_67" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_66" location="f1:26" file="f1" line="26"/>
   </OperatorMethod>
-  <Destructor id="_47" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?/>
-  <PointerType id="_48" type="_17" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_49" type="_64" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_50" type="_17c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_47" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?>
+    <Argument type="_68" location="f1:26" file="f1" line="26"/>
+  </Constructor>
+  <OperatorMethod id="_48" name="=" returns="_67" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_68" location="f1:26" file="f1" line="26"/>
+  </OperatorMethod>
+  <Destructor id="_49" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?/>
+  <PointerType id="_50" type="_17" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_51" type="_69" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_52" type="_17c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_17c" type="_17" const="1"/>
-  <PointerType id="_51" type="_64c" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_52" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_53" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?>
-    <Argument type="_65" location="f1:38" file="f1" line="38"/>
+  <PointerType id="_53" type="_69c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_54" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_55" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?>
+    <Argument type="_70" location="f1:38" file="f1" line="38"/>
   </Constructor>
-  <OperatorMethod id="_54" name="=" returns="_66" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_65" location="f1:38" file="f1" line="38"/>
+  <OperatorMethod id="_56" name="=" returns="_71" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_70" location="f1:38" file="f1" line="38"/>
   </OperatorMethod>
-  <Destructor id="_55" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?/>
-  <PointerType id="_56" type="_24" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_57" type="_67" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_58" type="_67c" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_59" name="void" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_60c" type="_60" const="1"/>
-  <CvQualifiedType id="_61c" type="_61" const="1"/>
-  <ReferenceType id="_62" type="_17c" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_63" type="_17" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_57" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?>
+    <Argument type="_72" location="f1:38" file="f1" line="38"/>
+  </Constructor>
+  <OperatorMethod id="_58" name="=" returns="_71" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_72" location="f1:38" file="f1" line="38"/>
+  </OperatorMethod>
+  <Destructor id="_59" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?/>
+  <PointerType id="_60" type="_24" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_61" type="_73" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_62" type="_73c" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_63" name="void" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_64c" type="_64" const="1"/>
-  <ReferenceType id="_65" type="_24c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_65c" type="_65" const="1"/>
+  <ReferenceType id="_66" type="_17c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_67" type="_17" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_68" type="_17" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_69c" type="_69" const="1"/>
+  <ReferenceType id="_70" type="_24c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_24c" type="_24" const="1"/>
-  <ReferenceType id="_66" type="_24" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_67c" type="_67" const="1"/>
+  <ReferenceType id="_71" type="_24" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_72" type="_24" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_73c" type="_73" const="1"/>
   <Namespace id="_2" name="::"/>
-  <ElaboratedType id="_60" keyword="struct" type="_3"/>
-  <ElaboratedType id="_61" keyword="enum" type="_10"/>
-  <ElaboratedType id="_64" keyword="union" type="_17"/>
-  <ElaboratedType id="_67" keyword="class" type="_24"/>
+  <ElaboratedType id="_64" keyword="struct" type="_3"/>
+  <ElaboratedType id="_65" keyword="enum" type="_10"/>
+  <ElaboratedType id="_69" keyword="union" type="_17"/>
+  <ElaboratedType id="_73" keyword="class" type="_24"/>
   <File id="f1" name=".*/test/input/Elaborated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Field-annotate.xml.txt
+++ b/test/expect/castxml1.any.Field-annotate.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="field" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0" annotation="an annotation" attributes="annotate\(an annotation\)"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Field-annotate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Field-deprecated.xml.txt
+++ b/test/expect/castxml1.any.Field-deprecated.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="field" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0" deprecation="Field Deprecated" attributes="deprecated"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0" deprecation="Field Deprecated" attributes="deprecated"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Field-deprecated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Field-init.xml.txt
+++ b/test/expect/castxml1.any.Field-init.xml.txt
@@ -1,23 +1,30 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="field_int" type="_9" init="123" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
-  <Field id="_4" name="field_str" type="_10" init="&quot;abc&quot;" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="field_int" type="_11" init="123" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Field id="_4" name="field_str" type="_12" init="&quot;abc&quot;" context="_1" access="private" location="f1:4" file="f1" line="4" offset="[0-9]+"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_11" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_14" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_10" type="_13c" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_14" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_15" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_12" type="_16c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_13c" type="_13" const="1"/>
+  <ReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_16c" type="_16" const="1"/>
   <Namespace id="_2" name="::"/>
-  <FundamentalType id="_13" name="char" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_16" name="char" size="[0-9]+" align="[0-9]+"/>
   <File id="f1" name=".*/test/input/Field-init.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Function-rvalue-reference.xml.txt
+++ b/test/expect/castxml1.any.Function-rvalue-reference.xml.txt
@@ -1,9 +1,17 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+">
-    <Argument type="_2" location="f1:1" file="f1" line="1"/>
+  <Function id="_1" name="start" returns="_4" context="_5" location="f1:1" file="f1" line="1" mangled="[^"]+">
+    <Argument type="_4" location="f1:1" file="f1" line="1"/>
   </Function>
-  <FundamentalType id="_2" name="int" size="[0-9]+" align="[0-9]+"/>
-  <Namespace id="_3" name="::"/>
+  <Function id="_2" name="start" returns="_4" context="_5" location="f1:2" file="f1" line="2" mangled="[^"]+">
+    <Argument type="_6" location="f1:2" file="f1" line="2"/>
+  </Function>
+  <Function id="_3" name="start" returns="_6" context="_5" location="f1:3" file="f1" line="3" mangled="[^"]+">
+    <Argument type="_4" location="f1:3" file="f1" line="3"/>
+    <Argument type="_4" location="f1:3" file="f1" line="3"/>
+  </Function>
+  <FundamentalType id="_4" name="int" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_6" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_5" name="::"/>
   <File id="f1" name=".*/test/input/Function-rvalue-reference.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-Argument-default-cast.xml.txt
+++ b/test/expect/castxml1.any.Method-Argument-default-cast.xml.txt
@@ -1,27 +1,34 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10 _11" size="[0-9]+" align="[0-9]+"/>
   <Class id="_3" name="Class" context="_1" access="private" location="f1:3" file="f1" line="3" incomplete="1"/>
-  <Typedef id="_4" name="Int" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4"/>
-  <Method id="_5" name="f" returns="_10" context="_1" access="private" location="f1:5" file="f1" line="5" mangled="[^"]+">
+  <Typedef id="_4" name="Int" type="_12" context="_1" access="private" location="f1:4" file="f1" line="4"/>
+  <Method id="_5" name="f" returns="_12" context="_1" access="private" location="f1:5" file="f1" line="5" mangled="[^"]+">
     <Argument type="_4" location="f1:5" file="f1" line="5" default="\(int\)0"/>
-    <Argument type="_11" location="f1:5" file="f1" line="5" default="\(start::Class \*\)0"/>
-    <Argument type="_11" location="f1:5" file="f1" line="5" default="static_cast&lt;start::Class \*&gt;\(0\)"/>
-    <Argument type="_11" location="f1:6" file="f1" line="6" default="reinterpret_cast&lt;start::Class \*&gt;\(0\)"/>
+    <Argument type="_13" location="f1:5" file="f1" line="5" default="\(start::Class \*\)0"/>
+    <Argument type="_13" location="f1:5" file="f1" line="5" default="static_cast&lt;start::Class \*&gt;\(0\)"/>
+    <Argument type="_13" location="f1:6" file="f1" line="6" default="reinterpret_cast&lt;start::Class \*&gt;\(0\)"/>
   </Method>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_8" name="=" returns="_13" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_8" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
-  <PointerType id="_11" type="_3" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_16" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_10" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_16" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_11" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_13" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_16" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-Argument-default-cast.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-Argument-default.xml.txt
+++ b/test/expect/castxml1.any.Method-Argument-default.xml.txt
@@ -1,23 +1,30 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Variable id="_3" name="C" type="_9c" init="0" context="_1" access="private" location="f1:3" file="f1" line="3" static="1" mangled="[^"]+"/>
-  <Method id="_4" name="method" returns="_9" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
-    <Argument type="_9" location="f1:4" file="f1" line="4" default="start::C"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_3" name="C" type="_11c" init="0" context="_1" access="private" location="f1:3" file="f1" line="3" static="1" mangled="[^"]+"/>
+  <Method id="_4" name="method" returns="_11" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_11" location="f1:4" file="f1" line="4" default="start::C"/>
   </Method>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_9c" type="_9" const="1"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_13" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-Argument-default.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-annotate.xml.txt
+++ b/test/expect/castxml1.any.Method-annotate.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)">
-    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)">
+    <Argument type="_10" location="f1:3" file="f1" line="3"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-annotate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-deprecated.xml.txt
+++ b/test/expect/castxml1.any.Method-deprecated.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="Method Deprecated" attributes="deprecated">
-    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="Method Deprecated" attributes="deprecated">
+    <Argument type="_10" location="f1:3" file="f1" line="3"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-deprecated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-final.xml.txt
+++ b/test/expect/castxml1.any.Method-final.xml.txt
@@ -1,38 +1,52 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7" bases="_8" size="[0-9]+" align="[0-9]+">
-    <Base type="_8" access="public" virtual="0" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8 _9" bases="_10" size="[0-9]+" align="[0-9]+">
+    <Base type="_10" access="public" virtual="0" offset="0"/>
   </Class>
-  <Method id="_3" name="method" returns="_9" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_10" mangled="[^"]+" attributes="final">
-    <Argument type="_9" location="f1:7" file="f1" line="7"/>
+  <Method id="_3" name="method" returns="_11" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_12" mangled="[^"]+" attributes="final">
+    <Argument type="_11" location="f1:7" file="f1" line="7"/>
   </Method>
-  <OperatorMethod id="_4" name="=" returns="_11" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_4" name="=" returns="_13" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
-  <Destructor id="_5" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_5" name="=" returns="_13" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_15" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:5" file="f1" line="5"/>
   </Constructor>
-  <Class id="_8" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_10" name="method" returns="_9" context="_8" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Constructor id="_9" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <Class id="_10" name="base" context="_2" location="f1:1" file="f1" line="1" members="_12 _16 _17 _18 _19 _20 _21" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_12" name="method" returns="_11" context="_10" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </Method>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_13" name="=" returns="_17" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_16" name="=" returns="_22" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_15" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_16" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_17" name="=" returns="_22" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_24" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_18" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <ReferenceType id="_17" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_18" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <Constructor id="_21" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_24" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <ReferenceType id="_22" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_23" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_24" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-final.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.any.Method-ms-dllexport.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport">
-    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport">
+    <Argument type="_10" location="f1:3" file="f1" line="3"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-ms-dllexport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.any.Method-ms-dllimport.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport">
-    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport">
+    <Argument type="_10" location="f1:3" file="f1" line="3"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-ms-dllimport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-override.xml.txt
+++ b/test/expect/castxml1.any.Method-override.xml.txt
@@ -1,38 +1,52 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7" bases="_8" size="[0-9]+" align="[0-9]+">
-    <Base type="_8" access="public" virtual="0" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8 _9" bases="_10" size="[0-9]+" align="[0-9]+">
+    <Base type="_10" access="public" virtual="0" offset="0"/>
   </Class>
-  <Method id="_3" name="method" returns="_9" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_10" mangled="[^"]+" attributes="override">
-    <Argument type="_9" location="f1:7" file="f1" line="7"/>
+  <Method id="_3" name="method" returns="_11" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_12" mangled="[^"]+" attributes="override">
+    <Argument type="_11" location="f1:7" file="f1" line="7"/>
   </Method>
-  <OperatorMethod id="_4" name="=" returns="_11" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_4" name="=" returns="_13" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
-  <Destructor id="_5" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_5" name="=" returns="_13" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_15" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:5" file="f1" line="5"/>
   </Constructor>
-  <Class id="_8" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_10" name="method" returns="_9" context="_8" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Constructor id="_9" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <Class id="_10" name="base" context="_2" location="f1:1" file="f1" line="1" members="_12 _16 _17 _18 _19 _20 _21" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_12" name="method" returns="_11" context="_10" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </Method>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_13" name="=" returns="_17" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_16" name="=" returns="_22" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_15" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_16" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_17" name="=" returns="_22" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_24" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_18" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <ReferenceType id="_17" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_18" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <Constructor id="_21" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_24" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <ReferenceType id="_22" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_23" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_24" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-override.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-overrides.xml.txt
+++ b/test/expect/castxml1.any.Method-overrides.xml.txt
@@ -1,38 +1,52 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7" bases="_8" size="[0-9]+" align="[0-9]+">
-    <Base type="_8" access="public" virtual="0" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7 _8 _9" bases="_10" size="[0-9]+" align="[0-9]+">
+    <Base type="_10" access="public" virtual="0" offset="0"/>
   </Class>
-  <Method id="_3" name="method" returns="_9" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_10" mangled="[^"]+">
-    <Argument type="_9" location="f1:7" file="f1" line="7"/>
+  <Method id="_3" name="method" returns="_11" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_12" mangled="[^"]+">
+    <Argument type="_11" location="f1:7" file="f1" line="7"/>
   </Method>
-  <OperatorMethod id="_4" name="=" returns="_11" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_4" name="=" returns="_13" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
-  <Destructor id="_5" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_5" name="=" returns="_13" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_15" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:5" file="f1" line="5"/>
   </Constructor>
-  <Class id="_8" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_10" name="method" returns="_9" context="_8" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Constructor id="_9" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <Class id="_10" name="base" context="_2" location="f1:1" file="f1" line="1" members="_12 _16 _17 _18 _19 _20 _21" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_12" name="method" returns="_11" context="_10" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </Method>
-  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_13" name="=" returns="_17" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_16" name="=" returns="_22" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_15" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_16" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_17" name="=" returns="_22" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_24" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_18" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <ReferenceType id="_17" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_18" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <Constructor id="_21" name="base" context="_10" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_24" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <ReferenceType id="_22" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_23" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_24" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-overrides.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method-rvalue-reference.xml.txt
+++ b/test/expect/castxml1.any.Method-rvalue-reference.xml.txt
@@ -1,18 +1,33 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3">
-    <Argument type="_7" location="f1:3" file="f1" line="3"/>
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </Constructor>
-  <OperatorMethod id="_4" name="=" returns="_7" context="_1" access="private" location="f1:5" file="f1" line="5" mangled="[^"]+">
-    <Argument type="_7" location="f1:5" file="f1" line="5"/>
+  <Constructor id="_4" name="start" context="_1" access="private" location="f1:4" file="f1" line="4">
+    <Argument type="_12" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_11" context="_1" access="private" location="f1:5" file="f1" line="5" mangled="[^"]+">
+    <Argument type="_11" location="f1:5" file="f1" line="5"/>
   </OperatorMethod>
-  <Method id="_5" name="method" returns="_8" context="_1" access="private" location="f1:7" file="f1" line="7" mangled="[^"]+">
-    <Argument type="_8" location="f1:7" file="f1" line="7"/>
+  <OperatorMethod id="_6" name="=" returns="_11" context="_1" access="private" location="f1:6" file="f1" line="6" mangled="[^"]+">
+    <Argument type="_12" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Method id="_7" name="method" returns="_13" context="_1" access="private" location="f1:7" file="f1" line="7" mangled="[^"]+">
+    <Argument type="_13" location="f1:7" file="f1" line="7"/>
   </Method>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_7" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_8" name="method" returns="_13" context="_1" access="private" location="f1:8" file="f1" line="8" mangled="[^"]+">
+    <Argument type="_14" location="f1:8" file="f1" line="8"/>
+  </Method>
+  <Method id="_9" name="method" returns="_14" context="_1" access="private" location="f1:9" file="f1" line="9" mangled="[^"]+">
+    <Argument type="_13" location="f1:9" file="f1" line="9"/>
+    <Argument type="_13" location="f1:9" file="f1" line="9"/>
+  </Method>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_13" name="int" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_13" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method-rvalue-reference.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Method.xml.txt
+++ b/test/expect/castxml1.any.Method.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+">
-    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+">
+    <Argument type="_10" location="f1:3" file="f1" line="3"/>
   </Method>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Method.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Namespace-Class-members.xml.txt
+++ b/test/expect/castxml1.any.Namespace-Class-members.xml.txt
@@ -1,20 +1,27 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
   <Namespace id="_1" name="start" context="_2" members="_3"/>
-  <Class id="_3" name="A" context="_1" location="f1:2" file="f1" line="2" members="_4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Variable id="_4" name="data" type="_9" context="_3" access="private" location="f1:4" file="f1" line="4" static="1" mangled="[^"]+"/>
+  <Class id="_3" name="A" context="_1" location="f1:2" file="f1" line="2" members="_4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_4" name="data" type="_11" context="_3" access="private" location="f1:4" file="f1" line="4" static="1" mangled="[^"]+"/>
   <Constructor id="_5" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+    <Argument type="_12" location="f1:2" file="f1" line="2"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_11" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:2" file="f1" line="2"/>
   </OperatorMethod>
-  <Destructor id="_8" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:2" file="f1" line="2"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_13" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:2" file="f1" line="2"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_3c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_3c" type="_3" const="1"/>
-  <ReferenceType id="_11" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_14" type="_3" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Namespace-Class-members.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.OperatorMethod-annotate.xml.txt
+++ b/test/expect/castxml1.any.OperatorMethod-annotate.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </OperatorMethod>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/OperatorMethod-annotate.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.OperatorMethod-deprecated.xml.txt
+++ b/test/expect/castxml1.any.OperatorMethod-deprecated.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="OperatorMethod Deprecated" attributes="deprecated">
-    <Argument type="_9" location="f1:4" file="f1" line="4"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="OperatorMethod Deprecated" attributes="deprecated">
+    <Argument type="_11" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/OperatorMethod-deprecated.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.OperatorMethod-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.any.OperatorMethod-ms-dllexport.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </OperatorMethod>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/OperatorMethod-ms-dllexport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.OperatorMethod-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.any.OperatorMethod-ms-dllimport.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </OperatorMethod>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/OperatorMethod-ms-dllimport.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.OperatorMethod.xml.txt
+++ b/test/expect/castxml1.any.OperatorMethod.xml.txt
@@ -1,21 +1,28 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+">
-    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_10" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+">
+    <Argument type="_11" location="f1:3" file="f1" line="3"/>
   </OperatorMethod>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/OperatorMethod.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.RValueReferenceType.xml.txt
+++ b/test/expect/castxml1.any.RValueReferenceType.xml.txt
@@ -1,5 +1,9 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Namespace id="_1" name="start" context="_2"/>
+  <Namespace id="_1" name="start" context="_2" members="_3"/>
+  <Typedef id="_3" name="type" type="_4" context="_1" location="f1:2" file="f1" line="2"/>
+  <RValueReferenceType id="_4" type="_5" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
+  <FundamentalType id="_5" name="int" size="[0-9]+" align="[0-9]+"/>
+  <File id="f1" name=".*/test/input/RValueReferenceType.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Typedef-to-Struct-anonymous.xml.txt
+++ b/test/expect/castxml1.any.Typedef-to-Struct-anonymous.xml.txt
@@ -2,18 +2,25 @@
 <CastXML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:3" file="f1" line="3"/>
   <ElaboratedType id="_2" keyword="struct" type="_4"/>
-  <Struct id="_4" name="" context="_3" location="f1:1" file="f1" line="1" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_4" name="" context="_3" location="f1:1" file="f1" line="1" members="_5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_5" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_10" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_8" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_9" type="_4c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_12" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_11" type="_4c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_4c" type="_4" const="1"/>
-  <ReferenceType id="_10" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_4" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Typedef-to-Struct-anonymous.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Typedef-to-Union-anonymous.xml.txt
+++ b/test/expect/castxml1.any.Typedef-to-Union-anonymous.xml.txt
@@ -2,18 +2,25 @@
 <CastXML[^>]*>
   <Typedef id="_1" name="start" type="_2" context="_3" location="f1:3" file="f1" line="3"/>
   <ElaboratedType id="_2" keyword="union" type="_4"/>
-  <Union id="_4" name="" context="_3" location="f1:1" file="f1" line="1" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Union id="_4" name="" context="_3" location="f1:1" file="f1" line="1" members="_5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_5" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_10" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_8" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_9" type="_4c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_12" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_11" type="_4c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_4c" type="_4" const="1"/>
-  <ReferenceType id="_10" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_4" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_3" name="::"/>
   <File id="f1" name=".*/test/input/Typedef-to-Union-anonymous.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.Variable-in-Class.xml.txt
+++ b/test/expect/castxml1.any.Variable-in-Class.xml.txt
@@ -1,19 +1,26 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
-  <Variable id="_3" name="static_field" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" static="1" mangled="[^"]+"/>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_3" name="static_field" type="_10" context="_1" access="private" location="f1:3" file="f1" line="3" static="1" mangled="[^"]+"/>
   <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_6" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_12" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Variable-in-Class.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.invalid-decl-for-type.xml.txt
+++ b/test/expect/castxml1.any.invalid-decl-for-type.xml.txt
@@ -1,32 +1,46 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Struct id="_1" name="start" context="_2" location="f1:12" file="f1" line="12" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
-  <Field id="_3" name="b" type="_9" context="_1" access="public" location="f1:14" file="f1" line="14" offset="0"/>
-  <Typedef id="_4" name="type" type="_10" context="_1" access="public" location="f1:15" file="f1" line="15"/>
+  <Struct id="_1" name="start" context="_2" location="f1:12" file="f1" line="12" members="_3 _4 _5 _6 _7 _8 _9 _10" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="b" type="_11" context="_1" access="public" location="f1:14" file="f1" line="14" offset="0"/>
+  <Typedef id="_4" name="type" type="_12" context="_1" access="public" location="f1:15" file="f1" line="15"/>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
-    <Argument type="_11" location="f1:12" file="f1" line="12"/>
+    <Argument type="_13" location="f1:12" file="f1" line="12"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_11" location="f1:12" file="f1" line="12"/>
+  <OperatorMethod id="_7" name="=" returns="_14" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:12" file="f1" line="12"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
-  <Struct id="_9" name="B&lt;Incomplete&gt;" context="_2" location="f1:7" file="f1" line="7" members="_13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
-  <Struct id="_10" name="A&lt;Incomplete&gt;" context="_2" location="f1:2" file="f1" line="2" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:12" file="f1" line="12"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_14" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_15" location="f1:12" file="f1" line="12"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <Struct id="_11" name="B&lt;Incomplete&gt;" context="_2" location="f1:7" file="f1" line="7" members="_16 _17 _18 _19 _20 _21" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_12" name="A&lt;Incomplete&gt;" context="_2" location="f1:2" file="f1" line="2" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_13" name="B" context="_9" access="public" location="f1:9" file="f1" line="9" inline="1"/>
-  <Constructor id="_14" name="B" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
-    <Argument type="_17" location="f1:7" file="f1" line="7"/>
+  <ReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_16" name="B" context="_11" access="public" location="f1:9" file="f1" line="9" inline="1"/>
+  <Constructor id="_17" name="B" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_22" location="f1:7" file="f1" line="7"/>
   </Constructor>
-  <OperatorMethod id="_15" name="=" returns="_18" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_17" location="f1:7" file="f1" line="7"/>
+  <OperatorMethod id="_18" name="=" returns="_23" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_22" location="f1:7" file="f1" line="7"/>
   </OperatorMethod>
-  <Destructor id="_16" name="B" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_17" type="_9c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_9c" type="_9" const="1"/>
-  <ReferenceType id="_18" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_19" name="B" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_24" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <OperatorMethod id="_20" name="=" returns="_23" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_24" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <Destructor id="_21" name="B" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_22" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <ReferenceType id="_23" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_24" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/invalid-decl-for-type.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.any.using-declaration-class.xml.txt
+++ b/test/expect/castxml1.any.using-declaration-class.xml.txt
@@ -1,39 +1,53 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8" bases="_9" size="[0-9]+" align="[0-9]+">
-    <Base type="_9" access="public" virtual="0" offset="0"/>
+  <Class id="_1" name="start" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8 _9 _10" bases="_11" size="[0-9]+" align="[0-9]+">
+    <Base type="_11" access="public" virtual="0" offset="0"/>
   </Class>
-  <Method id="_3" name="f" returns="_10" context="_9" access="protected" location="f1:4" file="f1" line="4" mangled="[^"]+">
-    <Argument type="_10" location="f1:4" file="f1" line="4"/>
+  <Method id="_3" name="f" returns="_12" context="_11" access="protected" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_12" location="f1:4" file="f1" line="4"/>
   </Method>
-  <Method id="_4" name="f" returns="_10" context="_1" access="private" location="f1:9" file="f1" line="9" mangled="[^"]+">
-    <Argument type="_11" location="f1:9" file="f1" line="9"/>
+  <Method id="_4" name="f" returns="_12" context="_1" access="private" location="f1:9" file="f1" line="9" mangled="[^"]+">
+    <Argument type="_13" location="f1:9" file="f1" line="9"/>
   </Method>
   <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
   <Constructor id="_6" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
-    <Argument type="_12" location="f1:6" file="f1" line="6"/>
+    <Argument type="_14" location="f1:6" file="f1" line="6"/>
   </Constructor>
-  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_12" location="f1:6" file="f1" line="6"/>
+  <OperatorMethod id="_7" name="=" returns="_15" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:6" file="f1" line="6"/>
   </OperatorMethod>
-  <Destructor id="_8" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
-  <Class id="_9" name="base" context="_2" location="f1:1" file="f1" line="1" members="_3 _14 _15 _16 _17" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
-  <FundamentalType id="_11" name="char" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_16" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_9" name="=" returns="_15" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_16" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_10" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <Class id="_11" name="base" context="_2" location="f1:1" file="f1" line="1" members="_3 _17 _18 _19 _20 _21 _22" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_13" name="char" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_14" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <Constructor id="_15" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_16" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_17" name="base" context="_11" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_18" name="base" context="_11" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_16" name="=" returns="_19" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
-    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_19" name="=" returns="_24" context="_11" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_23" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_17" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
-  <ReferenceType id="_18" type="_9c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_9c" type="_9" const="1"/>
-  <ReferenceType id="_19" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_20" name="base" context="_11" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_25" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_21" name="=" returns="_24" context="_11" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_25" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_22" name="base" context="_11" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_23" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <ReferenceType id="_24" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_25" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/using-declaration-class.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++11.Class-bases.xml.txt
+++ b/test/expect/castxml1.c++11.Class-bases.xml.txt
@@ -1,57 +1,85 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="private" virtual="0" offset="[0-9]+"/>
-    <Base type="_9" access="protected" virtual="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6 _7 _8" bases="_9 private:_10 protected:_11" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="private" virtual="0" offset="[0-9]+"/>
+    <Base type="_11" access="protected" virtual="1"/>
   </Class>
-  <OperatorMethod id="_3" name="=" returns="_10" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_3" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </OperatorMethod>
-  <Destructor id="_4" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_4" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </Constructor>
-  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_9" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_20 _21 _22 _23" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </Constructor>
+  <Class id="_9" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_15 _16 _17 _18 _19 _20" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_21 _22 _23 _24 _25 _26" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_11" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_27 _28 _29 _30 _31 _32" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_12" name="=" returns="_24" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_15" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_13" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_14" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
-  </Constructor>
-  <OperatorMethod id="_16" name="=" returns="_26" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <OperatorMethod id="_16" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_17" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_18" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_19" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <Destructor id="_17" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_18" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_20" name="=" returns="_28" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <Constructor id="_20" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_21" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
-  <Destructor id="_21" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_22" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_23" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <OperatorMethod id="_22" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Destructor id="_23" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_24" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_25" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <ReferenceType id="_24" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_25" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_26" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_27" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_29" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_26" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_27" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <OperatorMethod id="_28" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <Destructor id="_29" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_30" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_31" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <Constructor id="_32" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <ReferenceType id="_33" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_34" type="_9c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <RValueReferenceType id="_35" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_36" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_37" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_38" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_39" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_40" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <RValueReferenceType id="_41" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++11.Class-template-bases.xml.txt
+++ b/test/expect/castxml1.c++11.Class-template-bases.xml.txt
@@ -1,44 +1,65 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6" bases="_7 _8" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="public" virtual="0" offset="[0-9]+"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6 _7 _8" bases="_9 _10" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="public" virtual="0" offset="[0-9]+"/>
   </Class>
-  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <OperatorMethod id="_5" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_14 _15 _16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_20 _21 _22 _23 _24 _25" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_11" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_12" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_14" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_15" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_13" name="=" returns="_20" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_16" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <Constructor id="_16" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <Constructor id="_17" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_17" name="=" returns="_22" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_18" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_18" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <ReferenceType id="_19" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_20" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_21" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_22" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_19" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_21" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_22" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Constructor id="_23" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_24" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_25" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_26" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_27" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_29" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <ReferenceType id="_30" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_31" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++14.Class-bases.xml.txt
+++ b/test/expect/castxml1.c++14.Class-bases.xml.txt
@@ -1,57 +1,85 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="private" virtual="0" offset="[0-9]+"/>
-    <Base type="_9" access="protected" virtual="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6 _7 _8" bases="_9 private:_10 protected:_11" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="private" virtual="0" offset="[0-9]+"/>
+    <Base type="_11" access="protected" virtual="1"/>
   </Class>
-  <OperatorMethod id="_3" name="=" returns="_10" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_3" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </OperatorMethod>
-  <Destructor id="_4" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_4" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </Constructor>
-  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_9" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_20 _21 _22 _23" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </Constructor>
+  <Class id="_9" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_15 _16 _17 _18 _19 _20" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_21 _22 _23 _24 _25 _26" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_11" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_27 _28 _29 _30 _31 _32" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_12" name="=" returns="_24" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_15" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_13" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_14" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
-  </Constructor>
-  <OperatorMethod id="_16" name="=" returns="_26" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <OperatorMethod id="_16" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_17" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_18" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_19" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <Destructor id="_17" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_18" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_20" name="=" returns="_28" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <Constructor id="_20" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_21" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
-  <Destructor id="_21" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_22" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_23" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <OperatorMethod id="_22" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Destructor id="_23" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_24" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_25" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <ReferenceType id="_24" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_25" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_26" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_27" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_29" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_26" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_27" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <OperatorMethod id="_28" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <Destructor id="_29" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_30" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_31" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <Constructor id="_32" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <ReferenceType id="_33" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_34" type="_9c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <RValueReferenceType id="_35" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_36" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_37" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_38" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_39" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_40" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <RValueReferenceType id="_41" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++14.Class-template-bases.xml.txt
+++ b/test/expect/castxml1.c++14.Class-template-bases.xml.txt
@@ -1,44 +1,65 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6" bases="_7 _8" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="public" virtual="0" offset="[0-9]+"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6 _7 _8" bases="_9 _10" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="public" virtual="0" offset="[0-9]+"/>
   </Class>
-  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <OperatorMethod id="_5" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_14 _15 _16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_20 _21 _22 _23 _24 _25" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_11" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_12" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_14" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_15" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_13" name="=" returns="_20" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_16" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <Constructor id="_16" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <Constructor id="_17" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_17" name="=" returns="_22" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_18" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_18" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <ReferenceType id="_19" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_20" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_21" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_22" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_19" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_21" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_22" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Constructor id="_23" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_24" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_25" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_26" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_27" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_29" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <ReferenceType id="_30" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_31" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++17.Class-bases.xml.txt
+++ b/test/expect/castxml1.c++17.Class-bases.xml.txt
@@ -1,57 +1,85 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="private" virtual="0" offset="[0-9]+"/>
-    <Base type="_9" access="protected" virtual="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6 _7 _8" bases="_9 private:_10 protected:_11" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="private" virtual="0" offset="[0-9]+"/>
+    <Base type="_11" access="protected" virtual="1"/>
   </Class>
-  <OperatorMethod id="_3" name="=" returns="_10" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_3" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </OperatorMethod>
-  <Destructor id="_4" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_4" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </Constructor>
-  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_9" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_20 _21 _22 _23" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </Constructor>
+  <Class id="_9" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_15 _16 _17 _18 _19 _20" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_21 _22 _23 _24 _25 _26" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_11" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_27 _28 _29 _30 _31 _32" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_12" name="=" returns="_24" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_15" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_13" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_14" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
-  </Constructor>
-  <OperatorMethod id="_16" name="=" returns="_26" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <OperatorMethod id="_16" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_17" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_18" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_19" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <Destructor id="_17" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_18" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_20" name="=" returns="_28" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <Constructor id="_20" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_21" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
-  <Destructor id="_21" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_22" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_23" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <OperatorMethod id="_22" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Destructor id="_23" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_24" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_25" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <ReferenceType id="_24" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_25" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_26" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_27" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_29" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_26" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_27" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <OperatorMethod id="_28" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <Destructor id="_29" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_30" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_31" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <Constructor id="_32" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <ReferenceType id="_33" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_34" type="_9c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <RValueReferenceType id="_35" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_36" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_37" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_38" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_39" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_40" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <RValueReferenceType id="_41" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++17.Class-template-bases.xml.txt
+++ b/test/expect/castxml1.c++17.Class-template-bases.xml.txt
@@ -1,44 +1,65 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6" bases="_7 _8" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="public" virtual="0" offset="[0-9]+"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6 _7 _8" bases="_9 _10" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="public" virtual="0" offset="[0-9]+"/>
   </Class>
-  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <OperatorMethod id="_5" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_14 _15 _16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_20 _21 _22 _23 _24 _25" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_11" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_12" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_14" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_15" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_13" name="=" returns="_20" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_16" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <Constructor id="_16" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <Constructor id="_17" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_17" name="=" returns="_22" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_18" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_18" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <ReferenceType id="_19" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_20" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_21" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_22" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_19" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_21" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_22" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Constructor id="_23" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_24" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_25" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_26" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_27" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_29" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <ReferenceType id="_30" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_31" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++20.Class-bases.xml.txt
+++ b/test/expect/castxml1.c++20.Class-bases.xml.txt
@@ -1,57 +1,85 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6" bases="_7 private:_8 protected:_9" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="private" virtual="0" offset="[0-9]+"/>
-    <Base type="_9" access="protected" virtual="1"/>
+  <Class id="_1" name="start" context="_2" location="f1:10" file="f1" line="10" members="_3 _4 _5 _6 _7 _8" bases="_9 private:_10 protected:_11" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="private" virtual="0" offset="[0-9]+"/>
+    <Base type="_11" access="protected" virtual="1"/>
   </Class>
-  <OperatorMethod id="_3" name="=" returns="_10" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_3" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </OperatorMethod>
-  <Destructor id="_4" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"/>
-  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1">
-    <Argument type="_11" location="f1:10" file="f1" line="10"/>
+  <OperatorMethod id="_4" name="=" returns="_12" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:10" file="f1" line="10"/>
   </Constructor>
-  <Class id="_7" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_9" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_20 _21 _22 _23" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_8" name="start" context="_1" access="public" location="f1:10" file="f1" line="10" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:10" file="f1" line="10"/>
+  </Constructor>
+  <Class id="_9" name="base_public" context="_2" location="f1:1" file="f1" line="1" members="_15 _16 _17 _18 _19 _20" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="base_private" context="_2" location="f1:4" file="f1" line="4" members="_21 _22 _23 _24 _25 _26" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_11" name="base_protected" context="_2" location="f1:7" file="f1" line="7" members="_27 _28 _29 _30 _31 _32" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_13" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <OperatorMethod id="_12" name="=" returns="_24" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
+  <RValueReferenceType id="_14" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_15" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_13" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_14" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="base_public" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_25" location="f1:1" file="f1" line="1"/>
-  </Constructor>
-  <OperatorMethod id="_16" name="=" returns="_26" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <OperatorMethod id="_16" name="=" returns="_33" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_17" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_18" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"/>
-  <Constructor id="_19" name="base_private" context="_8" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1">
-    <Argument type="_27" location="f1:4" file="f1" line="4"/>
+  <Destructor id="_17" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_18" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_34" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_20" name="=" returns="_28" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <Constructor id="_20" name="base_public" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_35" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_21" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </OperatorMethod>
-  <Destructor id="_21" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_22" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"/>
-  <Constructor id="_23" name="base_protected" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1">
-    <Argument type="_29" location="f1:7" file="f1" line="7"/>
+  <OperatorMethod id="_22" name="=" returns="_36" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Destructor id="_23" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_24" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_25" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_37" location="f1:4" file="f1" line="4"/>
   </Constructor>
-  <ReferenceType id="_24" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_25" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_26" type="_8" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_27" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_29" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_26" name="base_private" context="_10" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_38" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_27" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <OperatorMethod id="_28" name="=" returns="_39" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <Destructor id="_29" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_30" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_31" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_40" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <Constructor id="_32" name="base_protected" context="_11" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_41" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <ReferenceType id="_33" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_34" type="_9c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <RValueReferenceType id="_35" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_36" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_37" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <RValueReferenceType id="_38" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_39" type="_11" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_40" type="_11c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_11c" type="_11" const="1"/>
+  <RValueReferenceType id="_41" type="_11" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++20.Class-template-bases.xml.txt
+++ b/test/expect/castxml1.c++20.Class-template-bases.xml.txt
@@ -1,44 +1,65 @@
 ^<\?xml version="1.0"\?>
 <CastXML[^>]*>
-  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6" bases="_7 _8" size="[0-9]+" align="[0-9]+">
-    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
-    <Base type="_8" access="public" virtual="0" offset="[0-9]+"/>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:14" file="f1" line="14" members="_3 _4 _5 _6 _7 _8" bases="_9 _10" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_10" access="public" virtual="0" offset="[0-9]+"/>
   </Class>
-  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </Constructor>
-  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_9" location="f1:14" file="f1" line="14"/>
+  <OperatorMethod id="_5" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:14" file="f1" line="14"/>
   </OperatorMethod>
-  <Destructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"/>
-  <Class id="_7" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_11 _12 _13 _14" size="[0-9]+" align="[0-9]+"/>
-  <Class id="_8" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_15 _16 _17 _18" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:14" file="f1" line="14"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:14" file="f1" line="14" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="non_dependent_base" context="_2" location="f1:1" file="f1" line="1" members="_14 _15 _16 _17 _18 _19" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_10" name="dependent_base&lt;int&gt;" context="_2" location="f1:5" file="f1" line="5" members="_20 _21 _22 _23 _24 _25" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
-  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
-  <Constructor id="_11" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_12" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_14" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_15" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_13" name="=" returns="_20" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_19" location="f1:1" file="f1" line="1"/>
+  <OperatorMethod id="_16" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_26" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_14" name="non_dependent_base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"/>
-  <Constructor id="_15" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <Constructor id="_16" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <Constructor id="_17" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </Constructor>
-  <OperatorMethod id="_17" name="=" returns="_22" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1" mangled="[^"]+">
-    <Argument type="_21" location="f1:5" file="f1" line="5"/>
+  <OperatorMethod id="_18" name="=" returns="_27" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
   </OperatorMethod>
-  <Destructor id="_18" name="dependent_base" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"/>
-  <ReferenceType id="_19" type="_7c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_7c" type="_7" const="1"/>
-  <ReferenceType id="_20" type="_7" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_21" type="_8c" size="[0-9]+" align="[0-9]+"/>
-  <CvQualifiedType id="_8c" type="_8" const="1"/>
-  <ReferenceType id="_22" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <Destructor id="_19" name="non_dependent_base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_20" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_21" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_22" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_29" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Constructor id="_23" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_24" name="=" returns="_30" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_31" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_25" name="dependent_base" context="_10" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_26" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_27" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_28" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_29" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <ReferenceType id="_30" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <RValueReferenceType id="_31" type="_10" size="[0-9]+" align="[0-9]+"/>
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-bases.cxx"/>
 </CastXML>$

--- a/test/expect/castxml1.c++98.Class-annotate.xml.txt
+++ b/test/expect/castxml1.c++98.Class-annotate.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-annotate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-base-offset.xml.txt
+++ b/test/expect/castxml1.c++98.Class-base-offset.xml.txt
@@ -1,0 +1,61 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:13" file="f1" line="13" members="_3 _4 _5 _6" bases="_7 _8 _9" size="[0-9]+" align="[0-9]+">
+    <Base type="_7" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_8" access="public" virtual="0" offset="[0-9]+"/>
+    <Base type="_9" access="public" virtual="0" offset="[0-9]+"/>
+  </Class>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:13" file="f1" line="13"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_11" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:13" file="f1" line="13"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <Class id="_7" name="base_1" context="_2" location="f1:1" file="f1" line="1" members="_12 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_8" name="base_2" context="_2" location="f1:5" file="f1" line="5" members="_17 _18 _19 _20 _21" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_9" name="base_3" context="_2" location="f1:9" file="f1" line="9" members="_22 _23 _24 _25 _26" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_12" name="b1" type="_27" context="_7" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Constructor id="_13" name="base_1" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_14" name="base_1" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_15" name="=" returns="_29" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_28" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_16" name="base_1" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Field id="_17" name="b2" type="_27" context="_8" access="private" location="f1:7" file="f1" line="7" offset="0"/>
+  <Constructor id="_18" name="base_2" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_19" name="base_2" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_30" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_20" name="=" returns="_31" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_30" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_21" name="base_2" context="_8" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Field id="_22" name="b3" type="_27" context="_9" access="private" location="f1:11" file="f1" line="11" offset="0"/>
+  <Constructor id="_23" name="base_3" context="_9" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_24" name="base_3" context="_9" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_32" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_25" name="=" returns="_33" context="_9" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_32" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Destructor id="_26" name="base_3" context="_9" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_27" name="char" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_28" type="_7c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_7c" type="_7" const="1"/>
+  <ReferenceType id="_29" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_30" type="_8c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <ReferenceType id="_31" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_32" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_33" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-base-offset.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-base-typedef.xml.txt
+++ b/test/expect/castxml1.c++98.Class-base-typedef.xml.txt
@@ -1,0 +1,31 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6" bases="_7" size="[0-9]+" align="[0-9]+">
+    <Base type="_7" access="public" virtual="0" offset="0"/>
+  </Class>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_8" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_9" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_8" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Class id="_7" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _11 _12 _13" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_10" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_11" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_12" name="=" returns="_15" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_13" name="base" context="_7" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_14" type="_7c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_7c" type="_7" const="1"/>
+  <ReferenceType id="_15" type="_7" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-base-typedef.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-deprecated-long.xml.txt
+++ b/test/expect/castxml1.c++98.Class-deprecated-long.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:4" file="f1" line="4" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" deprecation="Deprecated: Additional information about the deprecation of &apos;start&apos;which spreads over multiple lines &lt;this is more infomation&gt; can be found &quot;online&quot; " attributes="deprecated"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:4" file="f1" line="4"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:4" file="f1" line="4" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-deprecated-long.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-deprecated.xml.txt
+++ b/test/expect/castxml1.c++98.Class-deprecated.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" deprecation="Class Deprecated" attributes="deprecated"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-deprecated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-friends.xml.txt
+++ b/test/expect/castxml1.c++98.Class-friends.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6" befriending="_7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <Function id="_7" name="f" returns="_11" context="_2" location="f1:4" file="f1" line="4" mangled="[^"]+"/>
+  <ElaboratedType id="_8" keyword="class" type="_12"/>
+  <FundamentalType id="_11" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_12" name="A" context="_2" location="f1:1" file="f1" line="1" size="[0-9]+" align="[0-9]+"/>
+  <File id="f1" name=".*/test/input/Class-friends.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-implicit-member-array.xml.txt
+++ b/test/expect/castxml1.c++98.Class-implicit-member-array.xml.txt
@@ -1,0 +1,20 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ArrayType id="_8" min="0" max="1" type="_11"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-implicit-member-array.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-implicit-member-bad-base.xml.txt
+++ b/test/expect/castxml1.c++98.Class-implicit-member-bad-base.xml.txt
@@ -1,0 +1,30 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5" bases="_6" size="[0-9]+" align="[0-9]+">
+    <Base type="_6" access="public" virtual="0" offset="0"/>
+  </Class>
+  (<Constructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  |<Constructor id="_3" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  )<Destructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Class id="_6" name="base&lt;const int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_8 _9 _10 _11" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Field id="_8" name="data" type="_12c" context="_6" access="protected" location="f1:5" file="f1" line="5" offset="0"/>
+  <Constructor id="_9" name="base" context="_6" access="protected" location="f1:6" file="f1" line="6"/>
+  <Constructor id="_10" name="base" context="_6" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:2" file="f1" line="2"/>
+  </Constructor>
+  <Destructor id="_11" name="base" context="_6" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_12c" type="_12" const="1"/>
+  <ReferenceType id="_13" type="_6c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_6c" type="_6" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-implicit-member-bad-base.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-implicit-member-const-aggregate.xml.txt
+++ b/test/expect/castxml1.c++98.Class-implicit-member-const-aggregate.xml.txt
@@ -1,0 +1,15 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Struct id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_6c" context="_1" access="public" location="f1:3" file="f1" line="3" offset="0"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_6" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_6c" type="_6" const="1"/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-implicit-member-const-aggregate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-implicit-member-const.xml.txt
+++ b/test/expect/castxml1.c++98.Class-implicit-member-const.xml.txt
@@ -1,0 +1,16 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="data" type="_7c" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_7" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_7c" type="_7" const="1"/>
+  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-implicit-member-const.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-implicit-member-reference.xml.txt
+++ b/test/expect/castxml1.c++98.Class-implicit-member-reference.xml.txt
@@ -1,0 +1,16 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="ref" type="_7" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <File id="f1" name=".*/test/input/Class-implicit-member-reference.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-implicit-members.xml.txt
+++ b/test/expect/castxml1.c++98.Class-implicit-members.xml.txt
@@ -1,0 +1,20 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_1" context="_1" access="private" location="f1:3" file="f1" line="3" inline="1" mangled="[^"]+">
+    <Argument name="x" type="_8" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_9" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_8" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-implicit-members.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-member-Struct-anonymous.xml.txt
+++ b/test/expect/castxml1.c++98.Class-member-Struct-anonymous.xml.txt
@@ -1,0 +1,31 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_3" name="" context="_1" access="private" location="f1:3" file="f1" line="3" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_4" name="s" type="_13" context="_1" access="private" location="f1:5" file="f1" line="5" offset="0"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_9" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_10" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
+    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  </Constructor>
+  <OperatorMethod id="_11" name="=" returns="_17" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Destructor id="_12" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <ElaboratedType id="_13" keyword="struct" type="_3"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_16" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_3c" type="_3" const="1"/>
+  <ReferenceType id="_17" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-member-Struct-anonymous.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-member-Union-anonymous.xml.txt
+++ b/test/expect/castxml1.c++98.Class-member-Union-anonymous.xml.txt
@@ -1,0 +1,31 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Union id="_3" name="" context="_1" access="private" location="f1:3" file="f1" line="3" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_4" name="u" type="_13" context="_1" access="private" location="f1:5" file="f1" line="5" offset="0"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_9" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_10" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?>
+    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  </Constructor>
+  <OperatorMethod id="_11" name="=" returns="_17" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_16" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Destructor id="_12" name="" context="_3" access="public" location="f1:3" file="f1" line="3" inline="1" artificial="1"( throw="")?/>
+  <ElaboratedType id="_13" keyword="union" type="_3"/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_16" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_3c" type="_3" const="1"/>
+  <ReferenceType id="_17" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-member-Union-anonymous.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-member-template-access.xml.txt
+++ b/test/expect/castxml1.c++98.Class-member-template-access.xml.txt
@@ -1,0 +1,31 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_3" name="member&lt;char&gt;" context="_1" access="private" location="f1:4" file="f1" line="4" incomplete="1"/>
+  <Class id="_4" name="member&lt;int&gt;" context="_1" access="private" location="f1:11" file="f1" line="11" members="_10 _11 _12 _13" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_5" name="member_char" type="_3" context="_1" access="public" location="f1:9" file="f1" line="9"/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_15" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_14" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_10" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_11" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_16" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_12" name="=" returns="_17" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_16" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_13" name="member" context="_4" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_14" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_15" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_16" type="_4c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_4c" type="_4" const="1"/>
+  <ReferenceType id="_17" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-member-template-access.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-member-template.xml.txt
+++ b/test/expect/castxml1.c++98.Class-member-template.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" inline="1" mangled="[^"]+">
+    <Argument name="v" type="_8" location="f1:4" file="f1" line="4"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-member-template.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.c++98.Class-ms-dllexport.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" attributes="dllexport"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllexport">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-ms-dllexport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.c++98.Class-ms-dllimport.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+" attributes="dllimport"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+" attributes="dllimport">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-ms-dllimport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-partial-template-member-Typedef.xml.txt
+++ b/test/expect/castxml1.c++98.Class-partial-template-member-Typedef.xml.txt
@@ -1,0 +1,22 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;int &amp;&gt;" context="_2" location="f1:11" file="f1" line="11" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_3" name="Int" type="_9" context="_1" access="private" location="f1:6" file="f1" line="6"/>
+  <Method id="_4" name="method" returns="_9" context="_1" access="public" location="f1:9" file="f1" line="9" mangled="[^"]+">
+    <Argument type="_3" location="f1:9" file="f1" line="9"/>
+  </Method>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-partial-template-member-Typedef.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-Method-Argument-const.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-Method-Argument-const.xml.txt
@@ -1,0 +1,24 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_9" location="f1:4" file="f1" line="4"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_11" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="void" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_12c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_12c" type="_12" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <FundamentalType id="_12" name="int" size="[0-9]+" align="[0-9]+"/>
+  <File id="f1" name=".*/test/input/Class-template-Method-Argument-const.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-Method-Argument-default.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-Method-Argument-default.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_8" location="f1:4" file="f1" line="4" default="123"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template-Method-Argument-default.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-Method-return-const.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-Method-return-const.xml.txt
@@ -1,0 +1,20 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8c" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template-Method-return-const.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-friends.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-friends.xml.txt
@@ -1,0 +1,23 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:13" file="f1" line="13" members="_3 _4 _5 _6" befriending="_7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:13" file="f1" line="13"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_10" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:13" file="f1" line="13"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:13" file="f1" line="13" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <Function id="_7" name="f" returns="_11" context="_2" location="f1:9" file="f1" line="9" mangled="[^"]+">
+    <Argument type="_11" location="f1:4" file="f1" line="4"/>
+  </Function>
+  <ElaboratedType id="_8" keyword="class" type="_12"/>
+  <FundamentalType id="_11" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_12" name="A&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" incomplete="1"/>
+  <File id="f1" name=".*/test/input/Class-template-friends.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-member-Typedef-const.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-member-Typedef-const.xml.txt
@@ -1,0 +1,23 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;const int&gt;" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_3" name="IntConst" type="_9c" context="_1" access="private" location="f1:4" file="f1" line="4"/>
+  <Method id="_4" name="method" returns="_9c" context="_1" access="public" location="f1:7" file="f1" line="7" mangled="[^"]+">
+    <Argument type="_3" location="f1:7" file="f1" line="7"/>
+  </Method>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template-member-Typedef-const.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-member-Typedef.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-member-Typedef.xml.txt
@@ -1,0 +1,22 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:9" file="f1" line="9" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Typedef id="_3" name="Int" type="_9" context="_1" access="private" location="f1:4" file="f1" line="4"/>
+  <Method id="_4" name="method" returns="_9" context="_1" access="public" location="f1:7" file="f1" line="7" mangled="[^"]+">
+    <Argument type="_3" location="f1:7" file="f1" line="7"/>
+  </Method>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:9" file="f1" line="9"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:9" file="f1" line="9" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template-member-Typedef.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-member-template.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-member-template.xml.txt
@@ -1,0 +1,22 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:5" file="f1" line="5" inline="1" mangled="[^"]+">
+    <Argument type="_9" location="f1:5" file="f1" line="5"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_11" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="char" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template-member-template.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template-recurse.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template-recurse.xml.txt
@@ -1,0 +1,18 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Variable id="_1" name="start" type="_2" init="" context="_3" location="f1:20" file="f1" line="20"/>
+  <Struct id="_2" name="C&lt;void&gt;" context="_3" location="f1:11" file="f1" line="11" members="_4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_4" name="C" context="_2" access="public" location="f1:13" file="f1" line="13" inline="1"/>
+  <Constructor id="_5" name="C" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_8" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_9" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_8" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="C" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_2c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_2c" type="_2" const="1"/>
+  <ReferenceType id="_9" type="_2" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template-recurse.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class-template.xml.txt
+++ b/test/expect/castxml1.c++98.Class-template.xml.txt
@@ -1,0 +1,30 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start&lt;char&gt;" context="_4" location="f1:10" file="f1" line="10" incomplete="1"/>
+  <Class id="_2" name="start&lt;int&gt;" context="_4" location="f1:11" file="f1" line="11" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_3" name="start&lt;int &amp;&gt;" context="_4" location="f1:12" file="f1" line="12" members="_9 _10 _11 _12" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_5" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?>
+    <Argument type="_13" location="f1:11" file="f1" line="11"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_14" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_13" location="f1:11" file="f1" line="11"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_2" access="public" location="f1:11" file="f1" line="11" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_9" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_10" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
+    <Argument type="_15" location="f1:12" file="f1" line="12"/>
+  </Constructor>
+  <OperatorMethod id="_11" name="=" returns="_16" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_15" location="f1:12" file="f1" line="12"/>
+  </OperatorMethod>
+  <Destructor id="_12" name="start" context="_3" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_13" type="_2c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_2c" type="_2" const="1"/>
+  <ReferenceType id="_14" type="_2" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_15" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_3c" type="_3" const="1"/>
+  <ReferenceType id="_16" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_4" name="::"/>
+  <File id="f1" name=".*/test/input/Class-template.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Class.xml.txt
+++ b/test/expect/castxml1.c++98.Class.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Class.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Comment-Method.xml.txt
+++ b/test/expect/castxml1.c++98.Comment-Method.xml.txt
@@ -1,0 +1,22 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+" comment="c1">
+    <Argument type="_8" location="f1:4" file="f1" line="4"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <Comment id="c1" attached="_3" file="f1" begin_line="3" begin_column="3" begin_offset="16" end_line="3" end_column="24" end_offset="37"/>
+  <File id="f1" name=".*/test/input/Comment-Method.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Constructor-annotate.xml.txt
+++ b/test/expect/castxml1.c++98.Constructor-annotate.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Constructor-annotate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Constructor-deprecated.xml.txt
+++ b/test/expect/castxml1.c++98.Constructor-deprecated.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" deprecation="Constructor Deprecated" attributes="deprecated"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Constructor-deprecated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Constructor-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.c++98.Constructor-ms-dllexport.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" attributes="dllexport"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Constructor-ms-dllexport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Constructor-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.c++98.Constructor-ms-dllimport.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3" attributes="dllimport"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Constructor-ms-dllimport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Constructor.xml.txt
+++ b/test/expect/castxml1.c++98.Constructor.xml.txt
@@ -1,0 +1,17 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="private" location="f1:3" file="f1" line="3"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_5" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_7" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Constructor.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Converter-annotate.xml.txt
+++ b/test/expect/castxml1.c++98.Converter-annotate.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Converter-annotate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Converter-deprecated.xml.txt
+++ b/test/expect/castxml1.c++98.Converter-deprecated.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="Converter Deprecated" attributes="deprecated"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Converter-deprecated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Converter-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.c++98.Converter-ms-dllexport.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Converter-ms-dllexport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Converter-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.c++98.Converter-ms-dllimport.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Converter-ms-dllimport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Converter.xml.txt
+++ b/test/expect/castxml1.c++98.Converter.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Converter id="_3" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Converter.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Elaborated.xml.txt
+++ b/test/expect/castxml1.c++98.Elaborated.xml.txt
@@ -1,0 +1,99 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Namespace id="_1" name="start" context="_2" members="_3 _4 _5 _6 _7 _8 _9 _10 _11 _12 _13 _14 _15 _16 _17 _18 _19 _20 _21 _22 _23 _24 _25 _26 _27 _28 _29 _30 _31 _32 _33 _34"/>
+  <Struct id="_3" name="Foo1" context="_1" location="f1:4" file="f1" line="4" incomplete="1"/>
+  <Variable id="_4" name="s1" type="_35" context="_1" location="f1:6" file="f1" line="6" mangled="[^"]+"/>
+  <Variable id="_5" name="s2" type="_36" context="_1" location="f1:7" file="f1" line="7" mangled="[^"]+"/>
+  <Variable id="_6" name="s3" type="_37" context="_1" location="f1:8" file="f1" line="8" mangled="[^"]+"/>
+  <Variable id="_7" name="s4" type="_38" context="_1" location="f1:9" file="f1" line="9" mangled="[^"]+"/>
+  <Typedef id="_8" name="s5" type="_35" context="_1" location="f1:10" file="f1" line="10"/>
+  <Typedef id="_9" name="s6" type="_36" context="_1" location="f1:11" file="f1" line="11"/>
+  <Enumeration id="_10" name="Foo2" type="_39" context="_1" location="f1:14" file="f1" line="14" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_11" name="e1" type="_40" context="_1" location="f1:18" file="f1" line="18" mangled="[^"]+"/>
+  <Variable id="_12" name="e2" type="_41" context="_1" location="f1:19" file="f1" line="19" mangled="[^"]+"/>
+  <Variable id="_13" name="e3" type="_42" context="_1" location="f1:20" file="f1" line="20" mangled="[^"]+"/>
+  <Variable id="_14" name="e4" type="_43" context="_1" location="f1:21" file="f1" line="21" mangled="[^"]+"/>
+  <Typedef id="_15" name="e5" type="_40" context="_1" location="f1:22" file="f1" line="22"/>
+  <Typedef id="_16" name="e6" type="_41" context="_1" location="f1:23" file="f1" line="23"/>
+  <Union id="_17" name="Foo3" context="_1" location="f1:26" file="f1" line="26" members="_44 _45 _46 _47" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_18" name="u1" type="_48" context="_1" location="f1:30" file="f1" line="30" mangled="[^"]+"/>
+  <Variable id="_19" name="u2" type="_49" context="_1" location="f1:31" file="f1" line="31" mangled="[^"]+"/>
+  <Variable id="_20" name="u3" type="_50" context="_1" location="f1:32" file="f1" line="32" mangled="[^"]+"/>
+  <Variable id="_21" name="u4" type="_51" context="_1" location="f1:33" file="f1" line="33" mangled="[^"]+"/>
+  <Typedef id="_22" name="u5" type="_48" context="_1" location="f1:34" file="f1" line="34"/>
+  <Typedef id="_23" name="u6" type="_49" context="_1" location="f1:35" file="f1" line="35"/>
+  <Class id="_24" name="Foo4" context="_1" location="f1:38" file="f1" line="38" members="_52 _53 _54 _55" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_25" name="c1" type="_56" context="_1" location="f1:42" file="f1" line="42" mangled="[^"]+"/>
+  <Variable id="_26" name="c2" type="_57" context="_1" location="f1:43" file="f1" line="43" mangled="[^"]+"/>
+  <Variable id="_27" name="c3" type="_50" context="_1" location="f1:44" file="f1" line="44" mangled="[^"]+"/>
+  <Variable id="_28" name="c4" type="_58" context="_1" location="f1:45" file="f1" line="45" mangled="[^"]+"/>
+  <Typedef id="_29" name="c5" type="_56" context="_1" location="f1:46" file="f1" line="46"/>
+  <Typedef id="_30" name="c6" type="_57" context="_1" location="f1:47" file="f1" line="47"/>
+  <Function id="_31" name="func1" returns="_59" context="_1" location="f1:50" file="f1" line="50" mangled="[^"]+">
+    <Argument name="a1" type="_35" location="f1:50" file="f1" line="50"/>
+    <Argument name="a2" type="_36" location="f1:50" file="f1" line="50"/>
+  </Function>
+  <Function id="_32" name="func2" returns="_59" context="_1" location="f1:51" file="f1" line="51" mangled="[^"]+">
+    <Argument name="a3" type="_40" location="f1:51" file="f1" line="51"/>
+    <Argument name="a4" type="_41" location="f1:51" file="f1" line="51"/>
+  </Function>
+  <Function id="_33" name="func3" returns="_59" context="_1" location="f1:52" file="f1" line="52" mangled="[^"]+">
+    <Argument name="a5" type="_48" location="f1:52" file="f1" line="52"/>
+    <Argument name="a6" type="_49" location="f1:52" file="f1" line="52"/>
+  </Function>
+  <Function id="_34" name="func4" returns="_59" context="_1" location="f1:53" file="f1" line="53" mangled="[^"]+">
+    <Argument name="a7" type="_56" location="f1:53" file="f1" line="53"/>
+    <Argument name="a8" type="_57" location="f1:53" file="f1" line="53"/>
+  </Function>
+  <PointerType id="_35" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_36" type="_60" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_37" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_3c" type="_3" const="1"/>
+  <PointerType id="_38" type="_60c" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_39" name="(unsigned )?int" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_40" type="_10" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_41" type="_61" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_42" type="_10c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_10c" type="_10" const="1"/>
+  <PointerType id="_43" type="_61c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_44" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_45" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?>
+    <Argument type="_62" location="f1:26" file="f1" line="26"/>
+  </Constructor>
+  <OperatorMethod id="_46" name="=" returns="_63" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_62" location="f1:26" file="f1" line="26"/>
+  </OperatorMethod>
+  <Destructor id="_47" name="Foo3" context="_17" access="public" location="f1:26" file="f1" line="26" inline="1" artificial="1"( throw="")?/>
+  <PointerType id="_48" type="_17" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_49" type="_64" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_50" type="_17c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_17c" type="_17" const="1"/>
+  <PointerType id="_51" type="_64c" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_52" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_53" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?>
+    <Argument type="_65" location="f1:38" file="f1" line="38"/>
+  </Constructor>
+  <OperatorMethod id="_54" name="=" returns="_66" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_65" location="f1:38" file="f1" line="38"/>
+  </OperatorMethod>
+  <Destructor id="_55" name="Foo4" context="_24" access="public" location="f1:38" file="f1" line="38" inline="1" artificial="1"( throw="")?/>
+  <PointerType id="_56" type="_24" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_57" type="_67" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_58" type="_67c" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_59" name="void" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_60c" type="_60" const="1"/>
+  <CvQualifiedType id="_61c" type="_61" const="1"/>
+  <ReferenceType id="_62" type="_17c" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_63" type="_17" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_64c" type="_64" const="1"/>
+  <ReferenceType id="_65" type="_24c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_24c" type="_24" const="1"/>
+  <ReferenceType id="_66" type="_24" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_67c" type="_67" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <ElaboratedType id="_60" keyword="struct" type="_3"/>
+  <ElaboratedType id="_61" keyword="enum" type="_10"/>
+  <ElaboratedType id="_64" keyword="union" type="_17"/>
+  <ElaboratedType id="_67" keyword="class" type="_24"/>
+  <File id="f1" name=".*/test/input/Elaborated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Field-annotate.xml.txt
+++ b/test/expect/castxml1.c++98.Field-annotate.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="field" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0" annotation="an annotation" attributes="annotate\(an annotation\)"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Field-annotate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Field-deprecated.xml.txt
+++ b/test/expect/castxml1.c++98.Field-deprecated.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="field" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" offset="0" deprecation="Field Deprecated" attributes="deprecated"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Field-deprecated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-Argument-default-cast.xml.txt
+++ b/test/expect/castxml1.c++98.Method-Argument-default-cast.xml.txt
@@ -1,0 +1,27 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8 _9" size="[0-9]+" align="[0-9]+"/>
+  <Class id="_3" name="Class" context="_1" access="private" location="f1:3" file="f1" line="3" incomplete="1"/>
+  <Typedef id="_4" name="Int" type="_10" context="_1" access="private" location="f1:4" file="f1" line="4"/>
+  <Method id="_5" name="f" returns="_10" context="_1" access="private" location="f1:5" file="f1" line="5" mangled="[^"]+">
+    <Argument type="_4" location="f1:5" file="f1" line="5" default="\(int\)0"/>
+    <Argument type="_11" location="f1:5" file="f1" line="5" default="\(start::Class \*\)0"/>
+    <Argument type="_11" location="f1:5" file="f1" line="5" default="static_cast&lt;start::Class \*&gt;\(0\)"/>
+    <Argument type="_11" location="f1:6" file="f1" line="6" default="reinterpret_cast&lt;start::Class \*&gt;\(0\)"/>
+  </Method>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_8" name="=" returns="_13" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_9" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <PointerType id="_11" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-Argument-default-cast.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-Argument-default.xml.txt
+++ b/test/expect/castxml1.c++98.Method-Argument-default.xml.txt
@@ -1,0 +1,23 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_3" name="C" type="_9c" init="0" context="_1" access="private" location="f1:3" file="f1" line="3" static="1" mangled="[^"]+"/>
+  <Method id="_4" name="method" returns="_9" context="_1" access="private" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_9" location="f1:4" file="f1" line="4" default="start::C"/>
+  </Method>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_11" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-Argument-default.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-annotate.xml.txt
+++ b/test/expect/castxml1.c++98.Method-annotate.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)">
+    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-annotate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-deprecated.xml.txt
+++ b/test/expect/castxml1.c++98.Method-deprecated.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="Method Deprecated" attributes="deprecated">
+    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-deprecated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.c++98.Method-ms-dllexport.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport">
+    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-ms-dllexport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.c++98.Method-ms-dllimport.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport">
+    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-ms-dllimport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method-overrides.xml.txt
+++ b/test/expect/castxml1.c++98.Method-overrides.xml.txt
@@ -1,0 +1,38 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:5" file="f1" line="5" members="_3 _4 _5 _6 _7" bases="_8" size="[0-9]+" align="[0-9]+">
+    <Base type="_8" access="public" virtual="0" offset="0"/>
+  </Class>
+  <Method id="_3" name="method" returns="_9" context="_1" access="private" location="f1:7" file="f1" line="7" virtual="1" overrides="_10" mangled="[^"]+">
+    <Argument type="_9" location="f1:7" file="f1" line="7"/>
+  </Method>
+  <OperatorMethod id="_4" name="=" returns="_11" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_7" name="start" context="_1" access="public" location="f1:5" file="f1" line="5" inline="1" artificial="1"( throw="")?>
+    <Argument type="_12" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <Class id="_8" name="base" context="_2" location="f1:1" file="f1" line="1" members="_10 _13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_10" name="method" returns="_9" context="_8" access="private" location="f1:3" file="f1" line="3" virtual="1" mangled="[^"]+">
+    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <ReferenceType id="_11" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <OperatorMethod id="_13" name="=" returns="_17" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_14" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_15" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_16" name="base" context="_8" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <ReferenceType id="_17" type="_8" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_18" type="_8c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_8c" type="_8" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method-overrides.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Method.xml.txt
+++ b/test/expect/castxml1.c++98.Method.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Method id="_3" name="method" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+">
+    <Argument type="_8" location="f1:3" file="f1" line="3"/>
+  </Method>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Method.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Namespace-Class-members.xml.txt
+++ b/test/expect/castxml1.c++98.Namespace-Class-members.xml.txt
@@ -1,0 +1,20 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Namespace id="_1" name="start" context="_2" members="_3"/>
+  <Class id="_3" name="A" context="_1" location="f1:2" file="f1" line="2" members="_4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_4" name="data" type="_9" context="_3" access="private" location="f1:4" file="f1" line="4" static="1" mangled="[^"]+"/>
+  <Constructor id="_5" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_11" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:2" file="f1" line="2"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="A" context="_3" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_3c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_3c" type="_3" const="1"/>
+  <ReferenceType id="_11" type="_3" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Namespace-Class-members.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.OperatorMethod-annotate.xml.txt
+++ b/test/expect/castxml1.c++98.OperatorMethod-annotate.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" annotation="an annotation" attributes="annotate\(an annotation\)">
+    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/OperatorMethod-annotate.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.OperatorMethod-deprecated.xml.txt
+++ b/test/expect/castxml1.c++98.OperatorMethod-deprecated.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" deprecation="OperatorMethod Deprecated" attributes="deprecated">
+    <Argument type="_9" location="f1:4" file="f1" line="4"/>
+  </OperatorMethod>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/OperatorMethod-deprecated.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.OperatorMethod-ms-dllexport.xml.txt
+++ b/test/expect/castxml1.c++98.OperatorMethod-ms-dllexport.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllexport">
+    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/OperatorMethod-ms-dllexport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.OperatorMethod-ms-dllimport.xml.txt
+++ b/test/expect/castxml1.c++98.OperatorMethod-ms-dllimport.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+" attributes="dllimport">
+    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/OperatorMethod-ms-dllimport.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.OperatorMethod.xml.txt
+++ b/test/expect/castxml1.c++98.OperatorMethod.xml.txt
@@ -1,0 +1,21 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <OperatorMethod id="_3" name="&lt;&lt;" returns="_8" context="_1" access="private" location="f1:3" file="f1" line="3" mangled="[^"]+">
+    <Argument type="_9" location="f1:3" file="f1" line="3"/>
+  </OperatorMethod>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_8" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_10" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_8" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_9" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_10" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/OperatorMethod.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Typedef-to-Struct-anonymous.xml.txt
+++ b/test/expect/castxml1.c++98.Typedef-to-Struct-anonymous.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Typedef id="_1" name="start" type="_2" context="_3" location="f1:3" file="f1" line="3"/>
+  <ElaboratedType id="_2" keyword="struct" type="_4"/>
+  <Struct id="_4" name="" context="_3" location="f1:1" file="f1" line="1" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_5" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_4c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_4c" type="_4" const="1"/>
+  <ReferenceType id="_10" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/Typedef-to-Struct-anonymous.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Typedef-to-Union-anonymous.xml.txt
+++ b/test/expect/castxml1.c++98.Typedef-to-Union-anonymous.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Typedef id="_1" name="start" type="_2" context="_3" location="f1:3" file="f1" line="3"/>
+  <ElaboratedType id="_2" keyword="union" type="_4"/>
+  <Union id="_4" name="" context="_3" location="f1:1" file="f1" line="1" members="_5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_5" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_10" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="" context="_4" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_9" type="_4c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_4c" type="_4" const="1"/>
+  <ReferenceType id="_10" type="_4" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/Typedef-to-Union-anonymous.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.Variable-in-Class.xml.txt
+++ b/test/expect/castxml1.c++98.Variable-in-Class.xml.txt
@@ -1,0 +1,19 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:1" file="f1" line="1" members="_3 _4 _5 _6 _7" size="[0-9]+" align="[0-9]+"/>
+  <Variable id="_3" name="static_field" type="_8" context="_1" access="private" location="f1:3" file="f1" line="3" static="1" mangled="[^"]+"/>
+  <Constructor id="_4" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_6" name="=" returns="_10" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_9" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_7" name="start" context="_1" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <FundamentalType id="_8" name="int" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_10" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/Variable-in-Class.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.invalid-decl-for-type.xml.txt
+++ b/test/expect/castxml1.c++98.invalid-decl-for-type.xml.txt
@@ -1,0 +1,32 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Struct id="_1" name="start" context="_2" location="f1:12" file="f1" line="12" members="_3 _4 _5 _6 _7 _8" size="[0-9]+" align="[0-9]+"/>
+  <Field id="_3" name="b" type="_9" context="_1" access="public" location="f1:14" file="f1" line="14" offset="0"/>
+  <Typedef id="_4" name="type" type="_10" context="_1" access="public" location="f1:15" file="f1" line="15"/>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?>
+    <Argument type="_11" location="f1:12" file="f1" line="12"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_12" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_11" location="f1:12" file="f1" line="12"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:12" file="f1" line="12" inline="1" artificial="1"( throw="")?/>
+  <Struct id="_9" name="B&lt;Incomplete&gt;" context="_2" location="f1:7" file="f1" line="7" members="_13 _14 _15 _16" size="[0-9]+" align="[0-9]+"/>
+  <Struct id="_10" name="A&lt;Incomplete&gt;" context="_2" location="f1:2" file="f1" line="2" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_11" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_12" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_13" name="B" context="_9" access="public" location="f1:9" file="f1" line="9" inline="1"/>
+  <Constructor id="_14" name="B" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?>
+    <Argument type="_17" location="f1:7" file="f1" line="7"/>
+  </Constructor>
+  <OperatorMethod id="_15" name="=" returns="_18" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_17" location="f1:7" file="f1" line="7"/>
+  </OperatorMethod>
+  <Destructor id="_16" name="B" context="_9" access="public" location="f1:7" file="f1" line="7" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_17" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_18" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/invalid-decl-for-type.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c++98.using-declaration-class.xml.txt
+++ b/test/expect/castxml1.c++98.using-declaration-class.xml.txt
@@ -1,0 +1,39 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Class id="_1" name="start" context="_2" location="f1:6" file="f1" line="6" members="_3 _4 _5 _6 _7 _8" bases="_9" size="[0-9]+" align="[0-9]+">
+    <Base type="_9" access="public" virtual="0" offset="0"/>
+  </Class>
+  <Method id="_3" name="f" returns="_10" context="_9" access="protected" location="f1:4" file="f1" line="4" mangled="[^"]+">
+    <Argument type="_10" location="f1:4" file="f1" line="4"/>
+  </Method>
+  <Method id="_4" name="f" returns="_10" context="_1" access="private" location="f1:9" file="f1" line="9" mangled="[^"]+">
+    <Argument type="_11" location="f1:9" file="f1" line="9"/>
+  </Method>
+  <Constructor id="_5" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_6" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?>
+    <Argument type="_12" location="f1:6" file="f1" line="6"/>
+  </Constructor>
+  <OperatorMethod id="_7" name="=" returns="_13" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_12" location="f1:6" file="f1" line="6"/>
+  </OperatorMethod>
+  <Destructor id="_8" name="start" context="_1" access="public" location="f1:6" file="f1" line="6" inline="1" artificial="1"( throw="")?/>
+  <Class id="_9" name="base" context="_2" location="f1:1" file="f1" line="1" members="_3 _14 _15 _16 _17" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_10" name="int" size="[0-9]+" align="[0-9]+"/>
+  <FundamentalType id="_11" name="char" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_12" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_13" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_14" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <Constructor id="_15" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?>
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  </Constructor>
+  <OperatorMethod id="_16" name="=" returns="_19" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")? mangled="[^"]+">
+    <Argument type="_18" location="f1:1" file="f1" line="1"/>
+  </OperatorMethod>
+  <Destructor id="_17" name="base" context="_9" access="public" location="f1:1" file="f1" line="1" inline="1" artificial="1"( throw="")?/>
+  <ReferenceType id="_18" type="_9c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_9c" type="_9" const="1"/>
+  <ReferenceType id="_19" type="_9" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_2" name="::"/>
+  <File id="f1" name=".*/test/input/using-declaration-class.cxx"/>
+</CastXML>$


### PR DESCRIPTION
Implement the `OutputRValueReferenceType` method to generate the
`RValueRefernceType` element in the `--castxml-output=1` format.
Report the `type=""` of the pointee and queue it.

Normally we should increment the format *major* version number to
indicate the addition of an element that will require clients to be
updated.  However, the format major version has already been incremented
by #238 since the last release.

Fixes: #242
