### PR TITLE
Port to LLVM/Clang Git release/17.x as of 2023-08-15 (2f0fb9346d0)

### DIFF
--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -476,10 +476,6 @@ protected:
                              ) override
   {
     CI.getPreprocessor().setPredefines(this->UpdatePredefines(CI));
-
-    // Tell Clang not to tear down the parser at EOF.
-    CI.getPreprocessor().enableIncrementalProcessing();
-
     return true;
   }
 };
@@ -515,6 +511,28 @@ class CastXMLSyntaxOnlyAction
     } else {
       return nullptr;
     }
+  }
+
+protected:
+  bool BeginSourceFileAction(clang::CompilerInstance& CI
+#if LLVM_VERSION_MAJOR < 5
+                             ,
+                             llvm::StringRef Filename
+#endif
+                             ) override
+  {
+    this->CastXMLPredefines::BeginSourceFileAction(CI
+#if LLVM_VERSION_MAJOR < 5
+                                                   ,
+                                                   Filename
+#endif
+    );
+
+    // Tell Clang not to tear down the parser at EOF.
+    // We need it in ASTConsumer::HandleTranslationUnit.
+    CI.getPreprocessor().enableIncrementalProcessing();
+
+    return true;
   }
 
 public:


### PR DESCRIPTION
Since commit 825cca7df68c0282339e3d0ec64e75f40fd57ed9 (RunClang: Delay class implicit members until end of parsing, 2014-12-08, v0.2.0~211) we `enableIncrementalProcessing()` to defer parser tear down.

Since LLVM/Clang commit `247fa04116a6` ([clang] Add a new annotation token: annot_repl_input_end, 2023-05-16), incremental processing causes preprocessing to get stuck at the end of a file because it never gets an `eof` token.  See `clang/lib/Frontend/PrintPreprocessedOutput.cpp` in `DoPrintPreprocessedInput` and `DoPrintMacros`.

Fortunately we do not need incremental processing in preprocessing modes.