### PR TITLE
Port to LLVM/Clang Git main as of 2024-01-03

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
-  - Git ``main`` as of 2023-09-19 (``00ecef906b``)
+  - Git ``main`` as of 2024-01-03 (``155d5849da``)
   - Release ``17.0``
   - Release ``16.0``
   - Release ``15.0``

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -56,6 +56,23 @@ using optional = llvm::Optional<T>;
 }
 #endif
 
+#if LLVM_VERSION_MAJOR >= 16
+namespace cx {
+using FileEntryRef = clang::FileEntryRef;
+using OptionalFileEntryRef = clang::OptionalFileEntryRef;
+}
+#elif LLVM_VERSION_MAJOR >= 12
+namespace cx {
+using FileEntryRef = clang::FileEntryRef;
+using OptionalFileEntryRef = llvm::Optional<clang::FileEntryRef>;
+}
+#else
+namespace cx {
+using FileEntryRef = clang::FileEntry const*;
+using OptionalFileEntryRef = clang::FileEntry const*;
+}
+#endif
+
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -223,6 +240,23 @@ protected:
              << "\"/>\n";
     /* clang-format on */
   }
+
+  std::string getNameOfFileEntryRef(cx::FileEntryRef f) const
+  {
+#if LLVM_VERSION_MAJOR >= 12
+    return std::string(f.getName());
+#else
+    return std::string(f->getName());
+#endif
+  }
+  cx::OptionalFileEntryRef getFileEntryRefForID(clang::FileID id) const
+  {
+#if LLVM_VERSION_MAJOR >= 12
+    return this->CI.getSourceManager().getFileEntryRefForID(id);
+#else
+    return this->CI.getSourceManager().getFileEntryForID(id);
+#endif
+  }
 };
 
 class ASTVisitor : public ASTVisitorBase
@@ -364,7 +398,13 @@ class ASTVisitor : public ASTVisitorBase
   DumpId AddDumpNodeImpl(K k, bool complete);
 
   /** Allocate a dump node for a source file entry.  */
-  unsigned int AddDumpFile(clang::FileEntry const* f);
+  unsigned int AddDumpFile(cx::FileEntryRef f);
+#if LLVM_VERSION_MAJOR < 12
+  unsigned int AddDumpFile(clang::FileEntry const& f)
+  {
+    return this->AddDumpFile(&f);
+  }
+#endif
 
   /** Add class template specializations and instantiations for output.  */
   void AddClassTemplateDecl(clang::ClassTemplateDecl const* d,
@@ -636,7 +676,7 @@ private:
   QualNodesMap QualNodes;
 
   // Map from clang file entry to our source file index.
-  typedef std::map<clang::FileEntry const*, unsigned int> FileNodesMap;
+  typedef std::map<cx::FileEntryRef, unsigned int> FileNodesMap;
   FileNodesMap FileNodes;
 
   // Node traversal queue.
@@ -646,7 +686,7 @@ private:
   std::queue<CommentEntry> CommentQueue;
 
   // File traversal queue.
-  std::queue<clang::FileEntry const*> FileQueue;
+  std::queue<cx::FileEntryRef> FileQueue;
 
 public:
   ASTVisitor(clang::CompilerInstance& ci, clang::ASTContext& ctx,
@@ -925,7 +965,7 @@ ASTVisitor::DumpId ASTVisitor::AddDumpNodeImpl(K k, bool complete)
   return dn->Index;
 }
 
-unsigned int ASTVisitor::AddDumpFile(clang::FileEntry const* f)
+unsigned int ASTVisitor::AddDumpFile(cx::FileEntryRef f)
 {
   unsigned int& index = this->FileNodes[f];
   if (index == 0) {
@@ -1141,10 +1181,10 @@ void ASTVisitor::ProcessCommentQueue()
       clang::SourceManager const& sm = this->CI.getSourceManager();
       clang::FileID bid = bfl.getFileID();
       clang::FileID eid = efl.getFileID();
-      clang::FileEntry const* bf = sm.getFileEntryForID(bid);
-      clang::FileEntry const* ef = sm.getFileEntryForID(eid);
+      cx::OptionalFileEntryRef bf = this->getFileEntryRefForID(bid);
+      cx::OptionalFileEntryRef ef = this->getFileEntryRefForID(eid);
       if (bf && bf == ef) {
-        unsigned int fi = this->AddDumpFile(bf);
+        unsigned int fi = this->AddDumpFile(*bf);
         unsigned int boff = sm.getFileOffset(bfl);
         unsigned int eoff = sm.getFileOffset(efl);
         /* clang-format off */
@@ -1174,13 +1214,13 @@ void ASTVisitor::ProcessFileQueue()
     /* clang-format on */
   }
   while (!this->FileQueue.empty()) {
-    clang::FileEntry const* f = this->FileQueue.front();
+    cx::FileEntryRef f = this->FileQueue.front();
     this->FileQueue.pop();
     /* clang-format off */
     this->OS <<
       "  <File"
       " id=\"f" << this->FileNodes[f] << "\""
-      " name=\"" << encodeXML(std::string(f->getName())) << "\""
+      " name=\"" << encodeXML(this->getNameOfFileEntryRef(f)) << "\""
       "/>\n"
       ;
     /* clang-format on */
@@ -1383,9 +1423,9 @@ void ASTVisitor::PrintLocationAttribute(clang::Decl const* d)
   clang::SourceLocation sl = d->getLocation();
   if (sl.isValid()) {
     clang::FullSourceLoc fsl = this->CTX.getFullLoc(sl).getExpansionLoc();
-    if (clang::FileEntry const* f =
-          this->CI.getSourceManager().getFileEntryForID(fsl.getFileID())) {
-      unsigned int id = this->AddDumpFile(f);
+    if (cx::OptionalFileEntryRef f =
+          this->getFileEntryRefForID(fsl.getFileID())) {
+      unsigned int id = this->AddDumpFile(*f);
       unsigned int line = fsl.getExpansionLineNumber();
       /* clang-format off */
       this->OS <<


### PR DESCRIPTION
The return types of `getKeyword` and `getTagKind` are now defined using `enum class` types.

Also use `clang::FileEntryRef` with LLVM/Clang >= 12 to avoid a deprecation coming in LLVM/Clang 18.
