### PR TITLE
Port to LLVM/Clang Git release/18.x as of 2024-02-05 (900e7cbfdee)

### DIFF
--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -42,6 +42,14 @@
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <queue>
+#include <set>
+#include <string>
+#include <vector>
+
 #if LLVM_VERSION_MAJOR < 16
 #  define starts_with startswith
 #endif
@@ -84,14 +92,6 @@ using OptionalFileEntryRef = clang::FileEntry const*;
 #  define cx_ElaboratedTypeKeyword(x) clang::ETK_##x
 #  define cx_TagTypeKind(x) clang::TTK_##x
 #endif
-
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <queue>
-#include <set>
-#include <string>
-#include <vector>
 
 class ASTVisitorBase
 {

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -93,6 +93,10 @@ using OptionalFileEntryRef = clang::FileEntry const*;
 #  define starts_with startswith
 #endif
 
+#if LLVM_VERSION_MAJOR < 18
+#  define isPureVirtual isPure
+#endif
+
 class ASTVisitorBase
 {
 protected:
@@ -2282,7 +2286,7 @@ void ASTVisitor::OutputCXXMethodDecl(clang::CXXMethodDecl const* d,
   if (d->isVirtual()) {
     flags |= FH_Virtual;
   }
-  if (d->isPure()) {
+  if (d->isPureVirtual()) {
     flags |= FH_Pure;
   }
   if (d->isOverloadedOperator()) {
@@ -2312,7 +2316,7 @@ void ASTVisitor::OutputCXXConversionDecl(clang::CXXConversionDecl const* d,
   if (d->isVirtual()) {
     flags |= FH_Virtual;
   }
-  if (d->isPure()) {
+  if (d->isPureVirtual()) {
     flags |= FH_Pure;
   }
   this->OutputFunctionHelper(d, dn, "Converter", flags);
@@ -2348,7 +2352,7 @@ void ASTVisitor::OutputCXXDestructorDecl(clang::CXXDestructorDecl const* d,
   if (d->isVirtual()) {
     flags |= FH_Virtual;
   }
-  if (d->isPure()) {
+  if (d->isPureVirtual()) {
     flags |= FH_Pure;
   }
   this->OutputFunctionHelper(d, dn, "Destructor", flags,

--- a/src/Output.cxx
+++ b/src/Output.cxx
@@ -50,10 +50,6 @@
 #include <string>
 #include <vector>
 
-#if LLVM_VERSION_MAJOR < 16
-#  define starts_with startswith
-#endif
-
 #if LLVM_VERSION_MAJOR >= 16
 #  include <optional>
 namespace cx {
@@ -91,6 +87,10 @@ using OptionalFileEntryRef = clang::FileEntry const*;
 #else
 #  define cx_ElaboratedTypeKeyword(x) clang::ETK_##x
 #  define cx_TagTypeKind(x) clang::TTK_##x
+#endif
+
+#if LLVM_VERSION_MAJOR < 16
+#  define starts_with startswith
 #endif
 
 class ASTVisitorBase


### PR DESCRIPTION
`isPure` was renamed to `isPureVirtual`.
