### PR TITLE
README: Document support for LLVM/Clang 18.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Git ``main`` as of 2024-03-06 (``f7d354af57``)
   - Release ``18.1``
-  - Git ``main`` as of 2024-01-03 (``155d5849da``)
   - Release ``17.0``
   - Release ``16.0``
   - Release ``15.0``

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Release ``18.1``
   - Git ``main`` as of 2024-01-03 (``155d5849da``)
   - Release ``17.0``
   - Release ``16.0``


### PR DESCRIPTION
CastXML already compiles and passes all tests against this version.
