### PR TITLE
Fix compilation against LLVM/Clang 18.x with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   if(NOT LLVM_ENABLE_RTTI)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
   endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  string(APPEND CMAKE_CXX_FLAGS " -Zc:preprocessor")
 endif()
 if(CYGWIN OR MINGW)
   # Use GNU extensions on Windows as LLVM upstream does.


### PR DESCRIPTION
Since LLVM/Clang change [D157028](https://reviews.llvm.org/D157028), preprocessing the clang driver headers requires standard-conforming preprocessor behavior.  Add the MSVC `-Zc:preprocessor` flag for this, as LLVM/Clang change [D135128](https://reviews.llvm.org/D135128) did.

Fixes: #256