### PR TITLE
RunClang: Remove GCC builtin definitions for features Clang does not implement

### DIFF
--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -270,6 +270,33 @@ protected:
     if (this->Opts.HaveCC) {
       builtins += this->Opts.Predefines;
 
+      // Remove GCC builtin definitions for features Clang does not implement.
+      if (this->IsActualGNU(this->Opts.Predefines)) {
+        builtins += "#undef __BFLT16_DECIMAL_DIG__\n"
+                    "#undef __BFLT16_DENORM_MIN__\n"
+                    "#undef __BFLT16_DIG__\n"
+                    "#undef __BFLT16_DIG__\n"
+                    "#undef __BFLT16_EPSILON__\n"
+                    "#undef __BFLT16_HAS_DENORM__\n"
+                    "#undef __BFLT16_HAS_INFINITY__\n"
+                    "#undef __BFLT16_HAS_QUIET_NAN__\n"
+                    "#undef __BFLT16_IS_IEC_60559__\n"
+                    "#undef __BFLT16_MANT_DIG__\n"
+                    "#undef __BFLT16_MAX_10_EXP__\n"
+                    "#undef __BFLT16_MAX_EXP__\n"
+                    "#undef __BFLT16_MAX__\n"
+                    "#undef __BFLT16_MIN_10_EXP__\n"
+                    "#undef __BFLT16_MIN_EXP__\n"
+                    "#undef __BFLT16_MIN__\n"
+                    "#undef __BFLT16_NORM_MAX__\n"
+                    "#undef __SIZEOF_FLOAT80__\n"
+                    "#undef __STDCPP_BFLOAT16_T__\n"
+                    "#undef __STDCPP_FLOAT128_T__\n"
+                    "#undef __STDCPP_FLOAT16_T__\n"
+                    "#undef __STDCPP_FLOAT32_T__\n"
+                    "#undef __STDCPP_FLOAT64_T__\n";
+      }
+
       // Provide __builtin_va_arg_pack if simulating the actual GNU compiler.
       if (this->NeedBuiltinVarArgPack(this->Opts.Predefines)) {
         // Clang does not support this builtin, so fake it to tolerate

--- a/test/cc-gnu.c
+++ b/test/cc-gnu.c
@@ -47,6 +47,31 @@ int main(int argc, const char* argv[])
           "#define __vector __vector\n"
           "#define __has_last(x) x",
           ver_major);
+  /* Test GCC builtin definitions for features Clang does not implement.  */
+  fprintf(stdout,
+          "#define __BFLT16_DECIMAL_DIG__\n"
+          "#define __BFLT16_DENORM_MIN__\n"
+          "#define __BFLT16_DIG__\n"
+          "#define __BFLT16_DIG__\n"
+          "#define __BFLT16_EPSILON__\n"
+          "#define __BFLT16_HAS_DENORM__\n"
+          "#define __BFLT16_HAS_INFINITY__\n"
+          "#define __BFLT16_HAS_QUIET_NAN__\n"
+          "#define __BFLT16_IS_IEC_60559__\n"
+          "#define __BFLT16_MANT_DIG__\n"
+          "#define __BFLT16_MAX_10_EXP__\n"
+          "#define __BFLT16_MAX_EXP__\n"
+          "#define __BFLT16_MAX__\n"
+          "#define __BFLT16_MIN_10_EXP__\n"
+          "#define __BFLT16_MIN_EXP__\n"
+          "#define __BFLT16_MIN__\n"
+          "#define __BFLT16_NORM_MAX__\n"
+          "#define __SIZEOF_FLOAT80__\n"
+          "#define __STDCPP_BFLOAT16_T__\n"
+          "#define __STDCPP_FLOAT128_T__\n"
+          "#define __STDCPP_FLOAT16_T__\n"
+          "#define __STDCPP_FLOAT32_T__\n"
+          "#define __STDCPP_FLOAT64_T__\n");
   fprintf(stderr,
           "#include <...> search starts here:\n"
           " /some/include\n"


### PR DESCRIPTION
GCC 13 added support for C++23 fixed-size floating-point types and literal suffixes.  They are used in libstdc++ when compiled as C++23. Clang does not yet implement the types as of LLVM/Clang 18.  Remove the corresponding builtin definitions when simulating a GNU compiler.