### PR TITLE
RunClang: Tolerate GNU __attribute__((__assume__(...)))

### DIFF
--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -380,6 +380,12 @@ protected:
         builtins += "\n"
                     "#define __malloc__(...) __malloc__\n";
       }
+      if (this->NeedAttributeAssumeSuppression(this->Opts.Predefines)) {
+        // Clang does not support '__attribute__((__assume__(args...)))'
+        // as a statement attribute used in libstdc++ headers.
+        builtins += "\n"
+                    "#define __assume__(...)\n";
+      }
 
       // Clang's arm_neon.h checks for a feature macro not defined by GCC.
       if (this->NeedARMv8Intrinsics(this->Opts.Predefines)) {
@@ -490,6 +496,11 @@ protected:
   }
 
   bool NeedAttributeMallocArgs(std::string const& pd)
+  {
+    return this->IsActualGNU(pd);
+  }
+
+  bool NeedAttributeAssumeSuppression(std::string const& pd)
   {
     return this->IsActualGNU(pd);
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -724,11 +724,13 @@ unset(castxml_test_output_custom_start)
 unset(castxml_test_output_extra_arguments)
 
 set(castxml_test_output_extra_arguments --castxml-cc-gnu-c $<TARGET_FILE:cc-gnu>)
+castxml_test_output_c(GNU-attr-assume)
 castxml_test_output_c(GNU-attr-malloc-args)
 castxml_test_output_c(GNU-va_arg_pack)
 unset(castxml_test_output_extra_arguments)
 
 set(castxml_test_output_extra_arguments --castxml-cc-gnu $<TARGET_FILE:cc-gnu>)
+castxml_test_output(GNU-attr-assume)
 castxml_test_output(GNU-attr-malloc-args)
 castxml_test_output(GNU-va_arg_pack)
 unset(castxml_test_output_extra_arguments)

--- a/test/expect/castxml1.any.GNU-attr-assume.xml.txt
+++ b/test/expect/castxml1.any.GNU-attr-assume.xml.txt
@@ -1,0 +1,7 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/GNU-attr-assume.cxx"/>
+</CastXML>$

--- a/test/expect/castxml1.c.GNU-attr-assume.xml.txt
+++ b/test/expect/castxml1.c.GNU-attr-assume.xml.txt
@@ -1,0 +1,7 @@
+^<\?xml version="1.0"\?>
+<CastXML[^>]*>
+  <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/GNU-attr-assume.c"/>
+</CastXML>$

--- a/test/expect/cmd.cc-gnu-c-src-c-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-src-c-E.stdout.txt
@@ -3,6 +3,7 @@
 )?#define __GNUC_MINOR__ 1
 #define __GNUC__ 1(
 #define __MINGW32__ 1)?
+#define __assume__\(\.\.\.\)[ ]*
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
 #define __castxml__ [^

--- a/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
@@ -5,6 +5,7 @@
 #define __MINGW32__ 1)?
 #define __NO_MATH_INLINES 1
 #define __OPTIMIZE__ 1
+#define __assume__\(\.\.\.\)[ ]*
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
 #define __castxml__ [^

--- a/test/expect/cmd.cc-gnu-src-cxx-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-src-cxx-E.stdout.txt
@@ -3,6 +3,7 @@
 )?#define __GNUC_MINOR__ 1
 #define __GNUC__ 1(
 #define __MINGW32__ 1)?
+#define __assume__\(\.\.\.\)[ ]*
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
 #define __castxml__ [^

--- a/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
@@ -5,6 +5,7 @@
 #define __MINGW32__ 1)?
 #define __NO_MATH_INLINES 1
 #define __OPTIMIZE__ 1
+#define __assume__\(\.\.\.\)[ ]*
 #define __builtin_va_arg_pack\(\) 0
 #define __builtin_va_arg_pack_len\(\) 1
 #define __castxml__ [^

--- a/test/expect/gccxml.any.GNU-attr-assume.xml.txt
+++ b/test/expect/gccxml.any.GNU-attr-assume.xml.txt
@@ -1,0 +1,7 @@
+^<\?xml version="1.0"\?>
+<GCC_XML[^>]*>
+  <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1" mangled="[^"]+"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/GNU-attr-assume.cxx"/>
+</GCC_XML>$

--- a/test/expect/gccxml.c.GNU-attr-assume.xml.txt
+++ b/test/expect/gccxml.c.GNU-attr-assume.xml.txt
@@ -1,0 +1,7 @@
+^<\?xml version="1.0"\?>
+<GCC_XML[^>]*>
+  <Function id="_1" name="start" returns="_2" context="_3" location="f1:1" file="f1" line="1"/>
+  <FundamentalType id="_2" name="void" size="[0-9]+" align="[0-9]+"/>
+  <Namespace id="_3" name="::"/>
+  <File id="f1" name=".*/test/input/GNU-attr-assume.c"/>
+</GCC_XML>$

--- a/test/input/GNU-attr-assume.c
+++ b/test/input/GNU-attr-assume.c
@@ -1,0 +1,4 @@
+void start(void)
+{
+  __attribute__((__assume__(1)));
+}

--- a/test/input/GNU-attr-assume.cxx
+++ b/test/input/GNU-attr-assume.cxx
@@ -1,0 +1,4 @@
+void start(void)
+{
+  __attribute__((__assume__(1)));
+}


### PR DESCRIPTION
GCC 13 added support for an `__assume__(...)` statement attribute. GCC 14's libstdc++ uses it.  As of LLVM/Clang 18, it is not yet supported.  Work around the problem by mapping the attribute to an empty string.

Fixes: #259  