### PR TITLE
test: Fix expected cc-gnu predefined macro ordering

### DIFF
--- a/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-c-tgt-i386-opt-E.stdout.txt
@@ -18,7 +18,7 @@
 #define __castxml_major__ [0-9]+
 #define __castxml_minor__ [0-9]+
 #define __castxml_patch__ [0-9]+(
-#define __float80 __castxml__float80)?(
-#define __float128 __castxml__float128)?
+#define __float128 __castxml__float128)?(
+#define __float80 __castxml__float80)?
 #define __i386__ 1(
 #define __malloc__\(\.\.\.\) __malloc__)?$

--- a/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
+++ b/test/expect/cmd.cc-gnu-tgt-i386-opt-E.stdout.txt
@@ -19,7 +19,7 @@
 #define __castxml_minor__ [0-9]+
 #define __castxml_patch__ [0-9]+
 #define __cplusplus 199711L(
-#define __float80 __castxml__float80)?(
-#define __float128 __castxml__float128)?
+#define __float128 __castxml__float128)?(
+#define __float80 __castxml__float80)?
 #define __i386__ 1(
 #define __malloc__\(\.\.\.\) __malloc__)?$


### PR DESCRIPTION
Since #264 both `__float80` and `__float128` may individually be defined or not defined.  Fix the expected order when they are both defined.