### PR TITLE
README: Document support for LLVM/Clang 19.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Git ``main`` as of 2024-08-12 (``49777d7ffe``)
   - Release ``19.1``
-  - Git ``main`` as of 2024-03-06 (``f7d354af57``)
   - Release ``18.1``
   - Release ``17.0``
   - Release ``16.0``

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
+  - Release ``19.1``
   - Git ``main`` as of 2024-03-06 (``f7d354af57``)
   - Release ``18.1``
   - Release ``17.0``

--- a/test/expect/cmd.castxml-empty-c++98-c.stderr.txt
+++ b/test/expect/cmd.castxml-empty-c++98-c.stderr.txt
@@ -1,0 +1,1 @@
+^(warning: argument unused during compilation: '-c' \[-Wunused-command-line-argument\])?$

--- a/test/expect/cmd.gccxml-empty-c++98-c.stderr.txt
+++ b/test/expect/cmd.gccxml-empty-c++98-c.stderr.txt
@@ -1,0 +1,1 @@
+^(warning: argument unused during compilation: '-c' \[-Wunused-command-line-argument\])?$


### PR DESCRIPTION
CastXML already compiles and passes all tests against this version.
