### PR TITLE
test: Tolerate more predefined '__c*' macros from LLVM/Clang

### DIFF
--- a/test/expect/cmd.predefined-macros.stdout.txt.in
+++ b/test/expect/cmd.predefined-macros.stdout.txt.in
@@ -6,8 +6,8 @@
 #define __castxml_major__ @CastXML_VERSION_MAJOR@
 #define __castxml_minor__ @CastXML_VERSION_MINOR@
 #define __castxml_patch__ @CastXML_VERSION_PATCH@(
-#define __cdecl [^
-]*)?
+#define __c[^
+]*)*
 #define __clang__ 1(
 #define __clang_literal_encoding__ [^
 ]*)?


### PR DESCRIPTION
The output for the predefined macros test changed for clang 20 on ppc64le causing two test to start failing:

The following tests FAILED:
	 50 - cmd.gccxml-predefined-macros (Failed)
	 51 - cmd.castxml-predefined-macros (Failed)

The reason for the failure is that two new macros appear in the alphabetical list between the __castxml* and __clang* macros causing the expected test output to no longer match:

 #define __castxml_patch__ 11
 #define __cbcdtd __builtin_ppc_cbcdtd
 #define __cdtbcd __builtin_ppc_cdtbcd
 #define __clang__ 1