### PR TITLE
Port to LLVM/Clang Git main as of 2025-04-08

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
-  - Git ``master`` as of 2025-02-10 (``36530414e3``)
+  - Git ``master`` as of 2025-04-08 (``25e08c0b9c``)
   - Release ``20.1``
   - Release ``19.1``
   - Release ``18.1``

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ To build CastXML from source, first obtain the prerequisites:
   This version of CastXML has been tested with LLVM/Clang
 
   - Git ``master`` as of 2025-02-10 (``36530414e3``)
-  - Git ``release/20.x`` as of 2025-02-10 (``75e20e0b80``)
+  - Release ``20.1``
   - Release ``19.1``
   - Release ``18.1``
   - Release ``17.0``


### PR DESCRIPTION
`MemberPointerType` has a new way to get the containing class.
