### PR TITLE
 Port to LLVM/Clang Git main as of 2025-06-12

### DIFF
--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -788,10 +788,16 @@ static int runClangImpl(const char* const* argBeg, const char* const* argEnd,
                         Options const& opts)
 {
   // Construct a diagnostics engine for use while processing driver options.
+#if LLVM_VERSION_MAJOR >= 21
+  clang::DiagnosticOptions diagOpts;
+  clang::DiagnosticOptions& diagOptsRef = diagOpts;
+  clang::DiagnosticOptions& diagOptsPtr = diagOpts;
+#else
   llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOpts(
     new clang::DiagnosticOptions);
   clang::DiagnosticOptions& diagOptsRef = *diagOpts;
   clang::DiagnosticOptions* diagOptsPtr = &diagOptsRef;
+#endif
   llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagID(
     new clang::DiagnosticIDs());
 #if LLVM_VERSION_MAJOR >= 10

--- a/src/RunClang.cxx
+++ b/src/RunClang.cxx
@@ -790,6 +790,8 @@ static int runClangImpl(const char* const* argBeg, const char* const* argEnd,
   // Construct a diagnostics engine for use while processing driver options.
   llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOpts(
     new clang::DiagnosticOptions);
+  clang::DiagnosticOptions& diagOptsRef = *diagOpts;
+  clang::DiagnosticOptions* diagOptsPtr = &diagOptsRef;
   llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagID(
     new clang::DiagnosticIDs());
 #if LLVM_VERSION_MAJOR >= 10
@@ -808,16 +810,16 @@ static int runClangImpl(const char* const* argBeg, const char* const* argEnd,
     llvm::makeArrayRef(argBeg, argEnd),
 #  endif
     missingArgIndex, missingArgCount));
-  clang::ParseDiagnosticArgs(*diagOpts, args);
+  clang::ParseDiagnosticArgs(diagOptsRef, args);
 #else
   std::unique_ptr<llvm::opt::InputArgList> args(
     driverOpts->ParseArgs(argBeg, argEnd, missingArgIndex, missingArgCount));
-  clang::ParseDiagnosticArgs(*diagOpts, *args);
+  clang::ParseDiagnosticArgs(diagOptsRef, *args);
 #endif
-  clang::TextDiagnosticPrinter diagClient(llvm::errs(), &*diagOpts);
-  clang::DiagnosticsEngine diags(diagID, &*diagOpts, &diagClient,
+  clang::TextDiagnosticPrinter diagClient(llvm::errs(), diagOptsPtr);
+  clang::DiagnosticsEngine diags(diagID, diagOptsPtr, &diagClient,
                                  /*ShouldOwnClient=*/false);
-  clang::ProcessWarningOptions(diags, *diagOpts,
+  clang::ProcessWarningOptions(diags, diagOptsRef,
 #if LLVM_VERSION_MAJOR >= 20
                                *llvm::vfs::getRealFileSystem(),
 #endif

--- a/test/expect/castxml1.any.Class-template-constructor-template.xml.txt
+++ b/test/expect/castxml1.any.Class-template-constructor-template.xml.txt
@@ -1,5 +1,16 @@
 ^<\?xml version="1.0"\?>
-<CastXML[^>]*>
+<CastXML[^>]*>(
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5">
+    <Argument type="_6" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_4" name="=" returns="_7" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1" mangled="[^"]+">
+    <Argument type="_6" location="f1:2" file="f1" line="2"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"/>
+  <ReferenceType id="_6" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_7" type="_1" size="[0-9]+" align="[0-9]+"/>|
   <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5">
     <Argument type="_7" location="f1:5" file="f1" line="5"/>
@@ -14,7 +25,7 @@
   <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>)
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-constructor-template.cxx"/>
 </CastXML>$

--- a/test/expect/gccxml.any.Class-template-constructor-template.xml.txt
+++ b/test/expect/gccxml.any.Class-template-constructor-template.xml.txt
@@ -1,5 +1,16 @@
 ^<\?xml version="1.0"\?>
-<GCC_XML[^>]*>
+<GCC_XML[^>]*>(
+  <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5" size="[0-9]+" align="[0-9]+"/>
+  <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5">
+    <Argument type="_6" location="f1:5" file="f1" line="5"/>
+  </Constructor>
+  <OperatorMethod id="_4" name="=" returns="_7" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1" mangled="[^"]+">
+    <Argument type="_6" location="f1:2" file="f1" line="2"/>
+  </OperatorMethod>
+  <Destructor id="_5" name="start" context="_1" access="public" location="f1:2" file="f1" line="2" inline="1" artificial="1"/>
+  <ReferenceType id="_6" type="_1c" size="[0-9]+" align="[0-9]+"/>
+  <CvQualifiedType id="_1c" type="_1" const="1"/>
+  <ReferenceType id="_7" type="_1" size="[0-9]+" align="[0-9]+"/>|
   <Class id="_1" name="start&lt;int&gt;" context="_2" location="f1:2" file="f1" line="2" members="_3 _4 _5 _6" size="[0-9]+" align="[0-9]+"/>
   <Constructor id="_3" name="start" context="_1" access="public" location="f1:5" file="f1" line="5">
     <Argument type="_7" location="f1:5" file="f1" line="5"/>
@@ -14,7 +25,7 @@
   <ReferenceType id="_7" type="_1c" size="[0-9]+" align="[0-9]+"/>
   <CvQualifiedType id="_1c" type="_1" const="1"/>
   <ReferenceType id="_8" type="_1c" size="[0-9]+" align="[0-9]+"/>
-  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>
+  <ReferenceType id="_9" type="_1" size="[0-9]+" align="[0-9]+"/>)
   <Namespace id="_2" name="::"/>
   <File id="f1" name=".*/test/input/Class-template-constructor-template.cxx"/>
 </GCC_XML>$


### PR DESCRIPTION
`DiagnosticOptions` is no longer intrusively reference counted.

LLVM/Clang commit `8c5a307bd8d4` ([Clang] Bypass TAD during overload resolution if a perfect match exists, 2025-04-18) reduced duplication of reference-to-class-template-specialization types, so update our test case from commit fc66c82e1de6afd4453b7223c51de50428a40769 (test: Show duplication of reference-to-class-template-specialization types, 2014-03-27, `v0.2.0~258`).
