### PR TITLE
README: Document support for LLVM/Clang 23.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ To build CastXML from source, first obtain the prerequisites:
 * `LLVM/Clang`_ compiler SDK install tree built using the C++ compiler.
   This version of CastXML has been tested with LLVM/Clang
 
-  - Git ``master`` as of 2026-06-10 (``6f47b6de08``)
+  - Git ``main`` as of 2026-08-10 (``4f70753536``)
   - Release ``23.1``
   - Release ``22.1``
   - Release ``21.1``

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ To build CastXML from source, first obtain the prerequisites:
   This version of CastXML has been tested with LLVM/Clang
 
   - Git ``master`` as of 2026-06-10 (``6f47b6de08``)
+  - Release ``23.1``
   - Release ``22.1``
   - Release ``21.1``
   - Release ``20.1``


### PR DESCRIPTION
CastXML already compiles and passes all tests against this version.

Also document support for LLVM/Clang Git main as of 2026-08-10.
